### PR TITLE
Fix: IcingaCheckService with wildcard includes service name with wildcard in checkresult

### DIFF
--- a/doc/31-Changelog.md
+++ b/doc/31-Changelog.md
@@ -18,6 +18,7 @@ Released closed milestones can be found on [GitHub](https://github.com/Icinga/ic
 ### Bugfixes
 
 * [#75](https://github.com/Icinga/icinga-powershell-plugins/issues/75) Fixes unhandled arguments `FileSizeGreaterThan` and `FileSizeSmallerThan` for `Invoke-IcingaCheckDirectory`
+* [#79](https://github.com/Icinga/icinga-powershell-plugins/issues/79) Fixes service check to exclude provided service names in case they contain the wildcard symbol '*' which causes the check to always return unknown
 
 ## 1.2.0 (2020-08-28)
 

--- a/plugins/Invoke-IcingaCheckService.psm1
+++ b/plugins/Invoke-IcingaCheckService.psm1
@@ -112,6 +112,9 @@ function Invoke-IcingaCheckService()
    # Check our included services and add an unknown state for each service which was not found on the system
    foreach ($ServiceArg in $Service) {
       if ($null -eq $FetchedServices -Or $FetchedServices.ContainsKey($ServiceArg) -eq $FALSE) {
+         if ($ServiceArg.Contains('*')) {
+            continue;
+         }
          $ServicesPackage.AddCheck(
             (New-IcingaCheck -Name ([string]::Format('{0}: Service not found', $ServiceArg))).SetUnknown()
          );


### PR DESCRIPTION
We incorrectly included the wildcard name on the service args to match against our found services. We should exclude wildcard names which contain '*'
Fixes #79