### PR TITLE
Fix: Improves documentation and output for Invoke-IcingaCheckService

### DIFF
--- a/doc/31-Changelog.md
+++ b/doc/31-Changelog.md
@@ -14,6 +14,7 @@ Released closed milestones can be found on [GitHub](https://github.com/Icinga/ic
 ### Enhancements
 
 * [#73](https://github.com/Icinga/icinga-powershell-plugins/issues/73) Improves plugin creation Cmdlet to write a new permission section and to create the `plugins` doc folder in case it does not exist
+* [#78](https://github.com/Icinga/icinga-powershell-plugins/issues/78) Improves the documentation and output for `Invoke-IcingaCheckService` by adding metrics for all found services configured to run `Automatic` and adds service output on Verbosity 1 to show a list of all found services including their current state
 
 ### Bugfixes
 

--- a/doc/plugins/13-Invoke-IcingaCheckService.md
+++ b/doc/plugins/13-Invoke-IcingaCheckService.md
@@ -3,23 +3,33 @@
 
 ## Description
 
-Checks if a service has a specified status.
+Checks if defined services have a specific status or checks for all automatic services and if they are running
+and have not been terminated with exit code 0
 
-Invoke-icingaCheckService returns either 'OK' or 'CRITICAL', if a service status is matching status to be checked.
-If no specific services are configured to check for, the plugin will lookup all services which are configured to
-run automatically on the Windows startup and report an error in case the service is not running and was not
-terminated properly.
+Invoke-IcingaCheckService can be used to check the state of specified services against a user definable threshold.
+In addition the plugin can be used to check for all services which are configured to run automatically on Windows
+startup by not defining a specific service during plugin call. In this case the plugin will return 'CRITICAL'
+for services which are set to `Automatic` and not running, but only if the service ExitCode is not 0.
+
 More Information on https://github.com/Icinga/icinga-powershell-plugins
+
+## Permissions
+
+To execute this plugin you will require to grant the following user permissions.
+
+### WMI Permissions
+
+* Root\Cimv2
 
 ## Arguments
 
 | Argument | Type | Required | Default | Description |
 | ---      | ---  | ---      | ---     | ---         |
-| Service | Array | false |  | Used to specify an array of services which should be checked against the status. Supports '*' for wildcards. Seperated with ',' |
-| Exclude | Array | false | @() | Allows to exclude services which might come in handy for checking services which are configured to start automatically on Windows but are not running and werent exited properly. Seperated with ',' |
+| Service | Array | false |  | Used to specify an array of services which should be checked against the status. Supports '*' for wildcards. |
+| Exclude | Array | false | @() | Allows to exclude services which might come in handy for checking services which are configured to start automatically on Windows but are not running and weren't exited properly. |
 | Status | String | false | Running | Status for the specified service or services to check against. |
-| Verbosity | Int32 | false | 0 |  |
-| NoPerfData | SwitchParameter | false | False |  |
+| Verbosity | Int32 | false | 0 | Changes the behavior of the plugin output which check states are printed: 0 (default): Only service checks/packages with state not OK will be printed 1: Only services with not OK will be printed including OK checks of affected check packages including Package config 2: Everything will be printed regardless of the check state |
+| NoPerfData | SwitchParameter | false | False | Disables the performance data output of this plugin |
 
 ## Examples
 
@@ -32,19 +42,19 @@ Invoke-IcingaCheckService
 ### Example Output 1
 
 ```powershell
-[OK] Check package "Services"
+[OK] Check package "Services"| 'pending_paused_services'=0;; 'running_services'=80;; 'pending_continued_services'=0;; 'stopped_services'=5;; 'pending_started_services'=0;; 'service_count'=85;; 'pending_stopped_services'=0;; 'paused_services'=0;;
 ```
 
 ### Example Command 2
 
 ```powershell
-Invoke-IcingaCheckService -Service WiaRPC, Spooler -Status 'Running' -Verbose 3
+Invoke-IcingaCheckService -Service WiaRPC, Spooler -Status 'Running' -Verbosity 2
 ```
 
 ### Example Output 2
 
 ```powershell
-[CRITICAL]: Check package "Services" is [CRITICAL] (Match All) \_ [OK]: Service "Ereignisse zum Abrufen von Standbildern (WiaRPC)" is Stopped \_ [CRITICAL]: Service "Druckwarteschlange (Spooler)" Running is not matching Stopped
+[CRITICAL] Check package "Services" (Match All) - [CRITICAL] Service "Ereignisse zum Abrufen von Standbildern (WiaRPC)"\_ [OK] Service "Druckwarteschlange (Spooler)": Running\_ [CRITICAL] Service "Ereignisse zum Abrufen von Standbildern (WiaRPC)": Value "Stopped" is not matching threshold "Running"| 'pending_paused_services'=0;; 'running_services'=1;; 'pending_continued_services'=0;; 'stopped_services'=1;; 'pending_started_services'=0;; 'service_count'=2;; 'pending_stopped_services'=0;; 'paused_services'=0;; 'service_druckwarteschlange_spooler'=4;;4 'service_ereignisse_zum_abrufen_von_standbildern_wiarpc'=1;;4
 ```
 
 ### Example Command 3
@@ -56,7 +66,7 @@ Invoke-IcingaCheckService -Exclude icinga2
 ### Example Output 3
 
 ```powershell
-[OK] Check package "Services"
+[OK] Check package "Services"| 'pending_paused_services'=0;; 'running_services'=80;; 'pending_continued_services'=0;; 'stopped_services'=5;; 'pending_started_services'=0;; 'service_count'=85;; 'pending_stopped_services'=0;; 'paused_services'=0;;
 ```
 
 ### Example Command 4
@@ -68,5 +78,5 @@ Invoke-IcingaCheckService -Service '*csv*'
 ### Example Output 4
 
 ```powershell
-[CRITICAL] Check package "Services" - [CRITICAL] Service "Volumetric Audio Compositor-Dienst (VacSvc)", Service "Windows Update Medic Service (WaaSMedicSvc)", Service "Windows-Ereignissammlung (Wecsvc)" \_ [CRITICAL] Service "Volumetric Audio Compositor-Dienst (VacSvc)": Value "Stopped" is not matching threshold "Running" \_ [CRITICAL] Service "Windows Update Medic Service (WaaSMedicSvc)": Value "Stopped" is not matching threshold "Running" \_ [CRITICAL] Service "Windows-Ereignissammlung (Wecsvc)": Value "Stopped" is not matching threshold "Running"
+[CRITICAL] Check package "Services" - [CRITICAL] Service "Volumetric Audio Compositor-Dienst (VacSvc)", Service "Windows-Ereignissammlung (Wecsvc)", Service "Windows-Sofortverbindung - Konfigurationsregistrierungsstelle (wcncsvc)"\_ [CRITICAL] Service "Volumetric Audio Compositor-Dienst (VacSvc)": Value "Stopped" is not matching threshold "Running"\_ [CRITICAL] Service "Windows-Ereignissammlung (Wecsvc)": Value "Stopped" is not matching threshold "Running"\_ [CRITICAL] Service "Windows-Sofortverbindung - Konfigurationsregistrierungsstelle (wcncsvc)": Value "Stopped" is not matching threshold "Running"| 'pending_paused_services'=0;; 'running_services'=4;; 'pending_continued_services'=0;; 'stopped_services'=3;; 'pending_started_services'=0;; 'service_count'=7;; 'pending_stopped_services'=0;; 'paused_services'=0;; 'service_sicherheitscenter_wscsvc'=4;;4 'service_volumetric_audio_compositordienst_vacsvc'=1;;4 'service_windowsereignissammlung_wecsvc'=1;;4 'service_synchronisierungshost_2c66e0_onesyncsvc_2c66e0'=4;;4 'service_windowssofortverbindung_konfigurationsregistrierungsstelle_wcncsvc'=1;;4 'service_windows_update_medic_service_waasmedicsvc'=4;;4 'service_microsoft_passport_ngcsvc'=4;;4
 ```

--- a/plugins/Invoke-IcingaCheckService.psm1
+++ b/plugins/Invoke-IcingaCheckService.psm1
@@ -1,146 +1,166 @@
 <#
 .SYNOPSIS
-   Checks if a service has a specified status.
+    Checks if defined services have a specific status or checks for all automatic services and if they are running
+    and have not been terminated with exit code 0
 .DESCRIPTION
-   Invoke-icingaCheckService returns either 'OK' or 'CRITICAL', if a service status is matching status to be checked.
-   If no specific services are configured to check for, the plugin will lookup all services which are configured to
-   run automatically on the Windows startup and report an error in case the service is not running and was not
-   terminated properly.
-   More Information on https://github.com/Icinga/icinga-powershell-plugins
+    Invoke-IcingaCheckService can be used to check the state of specified services against a user definable threshold.
+    In addition the plugin can be used to check for all services which are configured to run automatically on Windows
+    startup by not defining a specific service during plugin call. In this case the plugin will return 'CRITICAL'
+    for services which are set to `Automatic` and not running, but only if the service ExitCode is not 0.
+
+    More Information on https://github.com/Icinga/icinga-powershell-plugins
 .FUNCTIONALITY
-   This module is intended to be used to check whether one or more services have a certain status. 
-   As soon as one of the specified services does not match the status, the function returns 'CRITICAL' instead of 'OK'.
+    This module is intended to be used to check whether one or more services have a certain status. 
+    As soon as one of the specified services does not match the status, the function returns 'CRITICAL' instead of 'OK'.
+.ROLE
+    ### WMI Permissions
+
+    * Root\Cimv2
 .EXAMPLE
-   PS>Invoke-IcingaCheckService
-   [OK] Check package "Services"
+    PS> Invoke-IcingaCheckService
+    [OK] Check package "Services"
+    | 'pending_paused_services'=0;; 'running_services'=80;; 'pending_continued_services'=0;; 'stopped_services'=5;; 'pending_started_services'=0;; 'service_count'=85;; 'pending_stopped_services'=0;; 'paused_services'=0;;
 .EXAMPLE
-   PS>Invoke-IcingaCheckService -Service WiaRPC, Spooler -Status 'Running' -Verbose 3
-   [CRITICAL]: Check package "Services" is [CRITICAL] (Match All)
-    \_ [OK]: Service "Ereignisse zum Abrufen von Standbildern (WiaRPC)" is Stopped
-    \_ [CRITICAL]: Service "Druckwarteschlange (Spooler)" Running is not matching Stopped
+    PS> Invoke-IcingaCheckService -Service WiaRPC, Spooler -Status 'Running' -Verbosity 2
+    [CRITICAL] Check package "Services" (Match All) - [CRITICAL] Service "Ereignisse zum Abrufen von Standbildern (WiaRPC)"
+    \_ [OK] Service "Druckwarteschlange (Spooler)": Running
+    \_ [CRITICAL] Service "Ereignisse zum Abrufen von Standbildern (WiaRPC)": Value "Stopped" is not matching threshold "Running"
+    | 'pending_paused_services'=0;; 'running_services'=1;; 'pending_continued_services'=0;; 'stopped_services'=1;; 'pending_started_services'=0;; 'service_count'=2;; 'pending_stopped_services'=0;; 'paused_services'=0;; 'service_druckwarteschlange_spooler'=4;;4 'service_ereignisse_zum_abrufen_von_standbildern_wiarpc'=1;;4
 .EXAMPLE
-   PS>Invoke-IcingaCheckService -Exclude icinga2
-   [OK] Check package "Services"
+    PS>Invoke-IcingaCheckService -Exclude icinga2
+    [OK] Check package "Services"
+    | 'pending_paused_services'=0;; 'running_services'=80;; 'pending_continued_services'=0;; 'stopped_services'=5;; 'pending_started_services'=0;; 'service_count'=85;; 'pending_stopped_services'=0;; 'paused_services'=0;;
 .EXAMPLE
-   PS>Invoke-IcingaCheckService -Service '*csv*'
-   [CRITICAL] Check package "Services" - [CRITICAL] Service "Volumetric Audio Compositor-Dienst (VacSvc)", Service "Windows Update Medic Service (WaaSMedicSvc)", Service "Windows-Ereignissammlung (Wecsvc)"
+    PS>Invoke-IcingaCheckService -Service '*csv*'
+    [CRITICAL] Check package "Services" - [CRITICAL] Service "Volumetric Audio Compositor-Dienst (VacSvc)", Service "Windows-Ereignissammlung (Wecsvc)", Service "Windows-Sofortverbindung - Konfigurationsregistrierungsstelle (wcncsvc)"
     \_ [CRITICAL] Service "Volumetric Audio Compositor-Dienst (VacSvc)": Value "Stopped" is not matching threshold "Running"
-    \_ [CRITICAL] Service "Windows Update Medic Service (WaaSMedicSvc)": Value "Stopped" is not matching threshold "Running"
     \_ [CRITICAL] Service "Windows-Ereignissammlung (Wecsvc)": Value "Stopped" is not matching threshold "Running"
+    \_ [CRITICAL] Service "Windows-Sofortverbindung - Konfigurationsregistrierungsstelle (wcncsvc)": Value "Stopped" is not matching threshold "Running"
+    | 'pending_paused_services'=0;; 'running_services'=4;; 'pending_continued_services'=0;; 'stopped_services'=3;; 'pending_started_services'=0;; 'service_count'=7;; 'pending_stopped_services'=0;; 'paused_services'=0;; 'service_sicherheitscenter_wscsvc'=4;;4 'service_volumetric_audio_compositordienst_vacsvc'=1;;4 'service_windowsereignissammlung_wecsvc'=1;;4 'service_synchronisierungshost_2c66e0_onesyncsvc_2c66e0'=4;;4 'service_windowssofortverbindung_konfigurationsregistrierungsstelle_wcncsvc'=1;;4 'service_windows_update_medic_service_waasmedicsvc'=4;;4 'service_microsoft_passport_ngcsvc'=4;;4
 .PARAMETER Service
-   Used to specify an array of services which should be checked against the status. Supports '*' for
-   wildcards. Seperated with ','
+    Used to specify an array of services which should be checked against the status. Supports '*' for
+    wildcards.
 .PARAMETER Exclude
-   Allows to exclude services which might come in handy for checking services which are configured to start automatically
-   on Windows but are not running and werent exited properly.
-   Seperated with ','
+    Allows to exclude services which might come in handy for checking services which are configured to start automatically
+    on Windows but are not running and weren't exited properly.
 .PARAMETER Status
-   Status for the specified service or services to check against.
+    Status for the specified service or services to check against.
+.PARAMETER NoPerfData
+    Disables the performance data output of this plugin
+.PARAMETER Verbosity
+    Changes the behavior of the plugin output which check states are printed:
+    0 (default): Only service checks/packages with state not OK will be printed
+    1: Only services with not OK will be printed including OK checks of affected check packages including Package config
+    2: Everything will be printed regardless of the check state
 .INPUTS
-   System.Array
+    System.Array
 .OUTPUTS
-   System.String
+    System.String
 .LINK
-   https://github.com/Icinga/icinga-powershell-plugins
+    https://github.com/Icinga/icinga-powershell-plugins
 .NOTES
 #>
 
 function Invoke-IcingaCheckService()
 {
-   param(
-      [array]$Service,
-      [array]$Exclude     = @(),
-      [ValidateSet('Stopped', 'StartPending', 'StopPending', 'Running', 'ContinuePending', 'PausePending', 'Paused')]
-      [string]$Status     = 'Running',
-      [ValidateSet(0, 1, 2, 3)]
-      [int]$Verbosity     = 0,
-      [switch]$NoPerfData
-   );
+    param (
+        [array]$Service,
+        [array]$Exclude     = @(),
+        [ValidateSet('Stopped', 'StartPending', 'StopPending', 'Running', 'ContinuePending', 'PausePending', 'Paused')]
+        [string]$Status     = 'Running',
+        [ValidateSet(0, 1, 2, 3)]
+        [int]$Verbosity     = 0,
+        [switch]$NoPerfData
+    );
 
-   $ServicesPackage      = New-IcingaCheckPackage -Name 'Services' -OperatorAnd -Verbose $Verbosity;
-   $ServicesCountPackage = New-IcingaCheckPackage -Name 'Count Services' -OperatorAnd -Verbose $Verbosity -Hidden;
-   $FetchedServices      = @{};
-   [int]$StoppedCount,[int]$StartPendingCount,[int]$StopPendingCount,[int]$RunningCount,[int]$ContinuePendingCount,[int]$PausePendingCount,[int]$PausedCount,[int]$ServicesCounted = 0
+    $ServicesPackage       = New-IcingaCheckPackage -Name 'Services' -OperatorAnd -Verbose $Verbosity;
+    $ServicesCountPackage  = New-IcingaCheckPackage -Name 'Count Services' -OperatorAnd -Verbose $Verbosity -Hidden;
+    $FetchedServices       = @{};
+    $ServiceSummary        = $null;
 
-   # Automatic load auto start services and check for errors in case no service
-   # to check for is configured
-   if ($Service.Count -eq 0) {
-      $AutoServices = Get-IcingaServices -Exclude $Exclude;
-      foreach ($autoservice in $AutoServices.Values) {
-         if ($autoservice.configuration.ExitCode -eq 0) {
-            continue;
-         }
-         if ($autoservice.configuration.StartType.Raw -ne $ProviderEnums.ServiceStartupType.Automatic) {
-            continue;
-         }
-         if ($autoservice.configuration.Status.Raw -eq $ProviderEnums.ServiceStatus.Running) {
-            continue;
-         }
+    # Automatic load auto start services and check for errors in case no service
+    # to check for is configured
+    if ($Service.Count -eq 0) {
+        $AutoServices = Get-IcingaServices -Exclude $Exclude;
+        foreach ($autoservice in $AutoServices.Values) {
 
-         $FetchedServices.Add(
-            $autoservice.metadata.ServiceName,
-            $autoservice
-         );
-      }
-   } else {
-      $FetchedServices = Get-IcingaServices -Service $Service -Exclude $Exclude;
-   }
+            # Skip services which are not defined to run automatically
+            if ($autoservice.configuration.StartType.Raw -ne $ProviderEnums.ServiceStartupType.Automatic) {
+                continue;
+            }
 
-   foreach ($services in $FetchedServices.Keys) {
-      $services = $FetchedServices[$services];
-      $IcingaCheck = $null;
+            $ServiceSummary = Add-IcingaServiceSummary -ServiceStatus $autoservice.configuration.Status.Raw -ServiceData $ServiceSummary;
 
-      $ServiceName     = Get-IcingaServiceCheckName -ServiceInput $services.metadata.DisplayName -Service $services;
-      $ConvertedStatus = ConvertTo-ServiceStatusCode -Status $Status;
-      $StatusRaw       = $services.configuration.Status.raw;
+            # Check if the service is running
+            if ($autoservice.configuration.Status.Raw -eq $ProviderEnums.ServiceStatus.Running) {
+                $ServicesPackage.AddCheck(
+                    (New-IcingaWindowsServiceCheckObject -Status 'Running' -Service $autoservice -NoPerfData)
+                );
+                continue;
+            }
 
-      $IcingaCheck = New-IcingaCheck -Name $ServiceName -Value $StatusRaw -ObjectExists $services -Translation $ProviderEnums.ServiceStatusName;
-      $IcingaCheck.CritIfNotMatch($ConvertedStatus) | Out-Null;
-      $ServicesPackage.AddCheck($IcingaCheck)
+            # Service is not running bug the ExitCode is 0 -> this is fine and should not raise a critical
+            if ($autoservice.configuration.ExitCode -eq 0) {
+                $ServicesPackage.AddCheck(
+                    (New-IcingaWindowsServiceCheckObject -Status 'Stopped' -Service $autoservice -NoPerfData)
+                );
+                continue;
+            }
 
-      switch($StatusRaw) {
-         {1 -contains $_} { $StoppedCount++;         $ServicesCounted++}
-         {2 -contains $_} { $StartPendingCount++;    $ServicesCounted++}
-         {3 -contains $_} { $StopPendingCount++;     $ServicesCounted++}
-         {4 -contains $_} { $RunningCount++;         $ServicesCounted++}
-         {5 -contains $_} { $ContinuePendingCount++; $ServicesCounted++}
-         {6 -contains $_} { $PausePendingCount++;    $ServicesCounted++}
-         {7 -contains $_} { $PausedCount++;          $ServicesCounted++}
-      }
-   }
+            # Services which should be running, but are not
+            $ServicesPackage.AddCheck(
+                (New-IcingaWindowsServiceCheckObject -Status 'Running' -Service $FetchedServices[$services] -NoPerfData)
+            );
+        }
+    } else {
+        $FetchedServices = Get-IcingaServices -Service $Service -Exclude $Exclude;
+        foreach ($services in $FetchedServices.Values) {
+            $ServicesPackage.AddCheck(
+                (New-IcingaWindowsServiceCheckObject -Status $Status -Service $services)
+            );
+    
+            $ServiceSummary = Add-IcingaServiceSummary -ServiceStatus $StatusRaw -ServiceData $ServiceSummary;
+        }
+    }
 
-   # Check our included services and add an unknown state for each service which was not found on the system
-   foreach ($ServiceArg in $Service) {
-      if ($null -eq $FetchedServices -Or $FetchedServices.ContainsKey($ServiceArg) -eq $FALSE) {
-         if ($ServiceArg.Contains('*')) {
-            continue;
-         }
-         $ServicesPackage.AddCheck(
-            (New-IcingaCheck -Name ([string]::Format('{0}: Service not found', $ServiceArg))).SetUnknown()
-         );
-      }
-   }
+    # Check our included services and add an unknown state for each service which was not found on the system
+    foreach ($ServiceArg in $Service) {
+        if ($null -eq $FetchedServices -Or $FetchedServices.ContainsKey($ServiceArg) -eq $FALSE) {
+            if ($ServiceArg.Contains('*')) {
+                continue;
+            }
+            $ServicesPackage.AddCheck(
+                (New-IcingaCheck -Name ([string]::Format('{0}: Service not found', $ServiceArg))).SetUnknown()
+            );
+        }
+    }
 
-   $IcingaStopped         = New-IcingaCheck -Name 'stopped services'           -Value $StoppedCount;
-   $IcingaStartPending    = New-IcingaCheck -Name 'pending started services'   -Value $StartPendingCount;
-   $IcingaStopPending     = New-IcingaCheck -Name 'pending stopped services'   -Value $StopPendingCount;
-   $IcingaRunning         = New-IcingaCheck -Name 'running services'           -Value $RunningCount;
-   $IcingaContinuePending = New-IcingaCheck -Name 'pending continued services' -Value $ContinuePendingCount;
-   $IcingaPausePending    = New-IcingaCheck -Name 'pending paused services'    -Value $PausePendingCount;
-   $IcingaPaused          = New-IcingaCheck -Name 'paused services'            -Value $PausePendingCount;
+    $ServicesCountPackage.AddCheck(
+        (New-IcingaCheck -Name 'stopped services' -Value $ServiceSummary.StoppedCount)
+    );
+    $ServicesCountPackage.AddCheck(
+        (New-IcingaCheck -Name 'pending started services' -Value $ServiceSummary.StartPendingCount)
+    );
+    $ServicesCountPackage.AddCheck(
+        (New-IcingaCheck -Name 'pending stopped services' -Value $ServiceSummary.StopPendingCount)
+    );
+    $ServicesCountPackage.AddCheck(
+        (New-IcingaCheck -Name 'running services' -Value $ServiceSummary.RunningCount)
+    );
+    $ServicesCountPackage.AddCheck(
+        (New-IcingaCheck -Name 'pending continued services' -Value $ServiceSummary.ContinuePendingCount)
+    );
+    $ServicesCountPackage.AddCheck(
+        (New-IcingaCheck -Name 'pending paused services' -Value $ServiceSummary.PausePendingCount)
+    );
+    $ServicesCountPackage.AddCheck(
+        (New-IcingaCheck -Name 'paused services' -Value $ServiceSummary.PausedCount)
+    );
+    $ServicesCountPackage.AddCheck(
+        (New-IcingaCheck -Name 'service count' -Value $ServiceSummary.ServicesCounted)
+    );
 
-   $IcingaCount           = New-IcingaCheck -Name 'service count'              -Value $ServicesCounted;
+     $ServicesPackage.AddCheck($ServicesCountPackage)
 
-   $ServicesCountPackage.AddCheck($IcingaStopped)
-   $ServicesCountPackage.AddCheck($IcingaStartPending)
-   $ServicesCountPackage.AddCheck($IcingaStopPending)
-   $ServicesCountPackage.AddCheck($IcingaRunning)
-   $ServicesCountPackage.AddCheck($IcingaContinuePending)
-   $ServicesCountPackage.AddCheck($IcingaPausePending)
-   $ServicesCountPackage.AddCheck($IcingaPaused)
-
-   $ServicesCountPackage.AddCheck($IcingaCount)
-   $ServicesPackage.AddCheck($ServicesCountPackage)
-
-   return (New-IcingaCheckResult -Name 'Services' -Check $ServicesPackage -NoPerfData $NoPerfData -Compile);
+    return (New-IcingaCheckResult -Name 'Services' -Check $ServicesPackage -NoPerfData $NoPerfData -Compile);
 }

--- a/provider/services/Add-IcingaServiceSummary.psm1
+++ b/provider/services/Add-IcingaServiceSummary.psm1
@@ -1,0 +1,82 @@
+<#
+.SYNOPSIS
+   Compares the provided state of a service and adds the result to an internal hashtable
+   to get to know the amount of services within a specific state, including amount of services.
+
+   Use the returned hashtable of this function as hashtable object for the -ServiceData argument
+   to add multiple service data on top of each other within a loop for example.
+.DESCRIPTION
+   Compares the provided state of a service and adds the result to an internal hashtable
+   to get to know the amount of services within a specific state, including amount of services.
+
+   Use the returned hashtable of this function as hashtable object for the -ServiceData argument
+   to add multiple service data on top of each other within a loop for example.
+.FUNCTIONALITY
+   Returns a hashtable with counts for states services are set to. Use this hashtable within a
+   loop as argument of -ServiceData to continually increases the count for different service states
+.EXAMPLE
+   PS> Add-IcingaServiceSummary -ServiceStatus 4 -ServiceData $null;
+.EXAMPLE
+   PS> Add-IcingaServiceSummary -ServiceStatus 4 -ServiceData $MyHashtable;
+.PARAMETER ServiceStatus
+   The current status of the service as integer
+.PARAMETER ServiceData
+   A hashtable object in which the status counts are stored in. If no object is given or the
+   hashtable is empty, as new hashtable will be initialized
+.INPUTS
+   System.Hashtable
+.OUTPUTS
+   System.Hashtable
+.LINK
+   https://github.com/Icinga/icinga-powershell-plugins
+.NOTES
+#>
+
+function Add-IcingaServiceSummary()
+{
+    param (
+        [int]$ServiceStatus     = 0,
+        [hashtable]$ServiceData = $null
+    );
+
+    if ($null -eq $ServiceData -Or $ServiceData.Count -eq 0) {
+        $ServiceData = @{
+            'StoppedCount'         = 0;
+            'StartPendingCount'    = 0;
+            'StopPendingCount'     = 0;
+            'RunningCount'         = 0;
+            'ContinuePendingCount' = 0;
+            'PausePendingCount'    = 0;
+            'PausedCount'          = 0;
+            'ServicesCounted'      = 0;
+        }
+    }
+
+    switch($ServiceStatus) {
+        $ProviderEnums.ServiceStatus.Stopped {
+            $ServiceData.StoppedCount += 1;
+        };
+        $ProviderEnums.ServiceStatus.StartPending {
+            $ServiceData.StartPendingCount += 1;
+        };
+        $ProviderEnums.ServiceStatus.StopPending {
+            $ServiceData.StopPendingCount += 1;
+        };
+        $ProviderEnums.ServiceStatus.Running {
+            $ServiceData.RunningCount += 1;
+        };
+        $ProviderEnums.ServiceStatus.ContinuePending {
+            $ServiceData.ContinuePendingCount += 1;
+        };
+        $ProviderEnums.ServiceStatus.PausePending {
+            $ServiceData.PausePendingCount += 1;
+        };
+        $ProviderEnums.ServiceStatus.Paused {
+            $ServiceData.PausedCount += 1;
+        };
+    }
+
+    $ServiceData.ServicesCounted += 1;
+
+    return $ServiceData;
+}

--- a/provider/services/New-IcingaWindowsServiceCheckObject.psm1
+++ b/provider/services/New-IcingaWindowsServiceCheckObject.psm1
@@ -1,0 +1,43 @@
+<#
+.SYNOPSIS
+   Uses a service object fetched by Get-IcingaServices and compares it to an
+   provided status to return a New-IcingaCheck object for generic usage.
+.DESCRIPTION
+   Uses a service object fetched by Get-IcingaServices and compares it to an
+   provided status to return a New-IcingaCheck object for generic usage.
+.FUNCTIONALITY
+   Uses a service object fetched by Get-IcingaServices and compares it to an
+   provided status to return a New-IcingaCheck object for generic usage.
+.PARAMETER Service
+   Service object fetched by Get-IcingaServices (single service entry only)
+.PARAMETER Status
+   The status of the service to compare it with
+.PARAMETER NoPerfData
+   Disables the performance data output of this plugin
+.INPUTS
+   System.Object
+.OUTPUTS
+   System.Object
+.LINK
+   https://github.com/Icinga/icinga-powershell-plugins
+.NOTES
+#>
+
+function New-IcingaWindowsServiceCheckObject()
+{
+    param (
+        $Service,
+        [ValidateSet('Stopped', 'StartPending', 'StopPending', 'Running', 'ContinuePending', 'PausePending', 'Paused')]
+        $Status,
+        [switch]$NoPerfData
+    );
+
+    $ServiceName     = Get-IcingaServiceCheckName -ServiceInput $Service.metadata.DisplayName -Service $Service;
+    $ConvertedStatus = ConvertTo-ServiceStatusCode -Status $Status;
+    $StatusRaw       = $Service.configuration.Status.raw;
+
+    $IcingaCheck     = New-IcingaCheck -Name $ServiceName -Value $StatusRaw -ObjectExists $Service -Translation $ProviderEnums.ServiceStatusName -NoPerfData:$NoPerfData;
+    $IcingaCheck.CritIfNotMatch($ConvertedStatus) | Out-Null;
+
+    return $IcingaCheck;
+}


### PR DESCRIPTION
Improves the documentation and output for `Invoke-IcingaCheckService` by adding metrics for all found services configured to run `Automatic` and adds service output on Verbosity 1 to show a list of all found services including their current state

Fixes #78