### PR TITLE
Fix: Throw unknown in case partition data cant be read

### DIFF
--- a/doc/31-Changelog.md
+++ b/doc/31-Changelog.md
@@ -19,6 +19,7 @@ Released closed milestones can be found on [GitHub](https://github.com/Icinga/ic
 
 * [#75](https://github.com/Icinga/icinga-powershell-plugins/issues/75) Fixes unhandled arguments `FileSizeGreaterThan` and `FileSizeSmallerThan` for `Invoke-IcingaCheckDirectory`
 * [#79](https://github.com/Icinga/icinga-powershell-plugins/issues/79) Fixes service check to exclude provided service names in case they contain the wildcard symbol '*' which causes the check to always return unknown
+* [#84](https://github.com/Icinga/icinga-powershell-plugins/issues/84) Fixes `Invoke-IcingaCheckUsedPartitionSpace` to throw an unknown in case permissions for certain partitions are missing and no data can be fetched. This resolves an issue for partitions reporting 100% usage.
 
 ## 1.2.0 (2020-08-28)
 

--- a/doc/plugins/16-Invoke-IcingaCheckUsedPartitionSpace.md
+++ b/doc/plugins/16-Invoke-IcingaCheckUsedPartitionSpace.md
@@ -7,7 +7,24 @@ Checks how much space on a partition is used.
 
 Invoke-IcingaCheckUsedPartition returns either 'OK', 'WARNING' or 'CRITICAL', based on the thresholds set.
 e.g 'C:' is at 8% usage, WARNING is set to 60, CRITICAL is set to 80. In this case the check will return OK.
+
+The plugin will return `UNKNOWN` in case partition data (size and free space) can not be fetched. This is
+normally happening in case the user the plugin is running with does not have permissions to fetch this
+specific partition data.
+
 More Information on https://github.com/Icinga/icinga-powershell-plugins
+
+## Permissions
+
+To execute this plugin you will require to grant the following user permissions.
+
+### WMI Permissions
+
+* Root\Cimv2
+
+### Performance Counter
+
+* LogicalDisk(*)\% free space
 
 ## Arguments
 

--- a/provider/disks/Icinga_ProviderDisks.psm1
+++ b/provider/disks/Icinga_ProviderDisks.psm1
@@ -58,7 +58,7 @@ function Get-IcingaDiskPartitions()
         )
         $diskPartition = $diskPartition.Replace('"', '');
         $diskDisk,$diskPartition = $diskPartition.split(',');
-        
+
         $diskPartition = $diskPartition.trim("Partition #");
         $diskDisk = $diskDisk.trim("Disk #");
 
@@ -75,14 +75,15 @@ function Get-IcingaDiskPartitions()
         $PartitionDiskByDriveLetter.Add(
             $driveLetter,
             @{
-                'Disk' = $diskDisk;
-                'Partition' = $diskPartition;
-                'Size' = $diskPartitionSize.Size;
+                'Disk'       = $diskDisk;
+                'Partition'  = $diskPartition;
+                'Size'       = $diskPartitionSize.Size;
                 'Free Space' = $DiskArray.Item([string]::Format('{0}:', $driveLetter))."% free space".value;
             }
         );
     }
-        return $PartitionDiskByDriveLetter;
+
+    return $PartitionDiskByDriveLetter;
 }
 
 function Join-IcingaPhysicalDiskDataPerfCounter()


### PR DESCRIPTION
Fixes `Invoke-IcingaCheckUsedPartitionSpace` to throw an unknown in case permissions for certain partitions are missing and no data can be fetched. This resolves an issue for partitions reporting 100% usage.