### PR TITLE
Feature: Add support to ignore empty checks on UsedPartitionSpace plugin and ignore Unknowns

### DIFF
--- a/doc/31-Changelog.md
+++ b/doc/31-Changelog.md
@@ -15,13 +15,13 @@ Released closed milestones can be found on [GitHub](https://github.com/Icinga/ic
 
 * [#73](https://github.com/Icinga/icinga-powershell-plugins/issues/73) Improves plugin creation Cmdlet to write a new permission section and to create the `plugins` doc folder in case it does not exist
 * [#78](https://github.com/Icinga/icinga-powershell-plugins/issues/78) Improves the documentation and output for `Invoke-IcingaCheckService` by adding metrics for all found services configured to run `Automatic` and adds service output on Verbosity 1 to show a list of all found services including their current state
+* [#85](https://github.com/Icinga/icinga-powershell-plugins/issues/85) Adds support on `Invoke-IcingaCheckUsedPartitionSpace` to ignore a `Unknown` in case all checks are filtered out. This will then return `Ok` instead if argument `-IgnoreEmptyChecks` is set. In addition you can now use `-SkipUnknown` which will transform an `Unknown` of partitions without data to `Ok`. Reworks [#84](https://github.com/Icinga/icinga-powershell-plugins/issues/84)
 
 ### Bugfixes
 
 * [#75](https://github.com/Icinga/icinga-powershell-plugins/issues/75) Fixes unhandled arguments `FileSizeGreaterThan` and `FileSizeSmallerThan` for `Invoke-IcingaCheckDirectory`
 * [#77](https://github.com/Icinga/icinga-powershell-plugins/issues/77) Fix wrong filtering for EventIds for `Invoke-IcingaCheckEventLog` and improve the output by adding the EventLog messages on severity 1. In addition we now allow the filtering for message sources and increase performance by fetching EventLog data for new checks from the last 2 hours only
 * [#79](https://github.com/Icinga/icinga-powershell-plugins/issues/79) Fixes service check to exclude provided service names in case they contain the wildcard symbol '*' which causes the check to always return unknown
-* [#84](https://github.com/Icinga/icinga-powershell-plugins/issues/84) Fixes `Invoke-IcingaCheckUsedPartitionSpace` to throw an unknown in case permissions for certain partitions are missing and no data can be fetched. This resolves an issue for partitions reporting 100% usage.
 * [#86](https://github.com/Icinga/icinga-powershell-plugins/pull/86) Fixes `Get-IcingaCPUCount` returns wrong count on empty arguments
 
 ## 1.2.0 (2020-08-28)

--- a/doc/plugins/16-Invoke-IcingaCheckUsedPartitionSpace.md
+++ b/doc/plugins/16-Invoke-IcingaCheckUsedPartitionSpace.md
@@ -34,8 +34,10 @@ To execute this plugin you will require to grant the following user permissions.
 | Critical | Object | false |  | Used to specify a Critical threshold. In this case an integer value. |
 | Include | Array | false | @() | Used to specify an array of partitions to be included. If not set, the check expects that all not excluded partitions should be checked. e.g. 'C:\','D:\' |
 | Exclude | Array | false | @() | Used to specify an array of partitions to be excluded. e.g. 'C:\','D:\' |
-| NoPerfData | SwitchParameter | false | False |  |
-| Verbosity | Int32 | false | 0 |  |
+| IgnoreEmptyChecks | SwitchParameter | false | False | Overrides the default behaviour of the plugin in case no check element is left for being checked (if all elements are filtered out for example). Instead of returning `Unknown` the plugin will return `Ok` instead if this argument is set. |
+| NoPerfData | SwitchParameter | false | False | Disables the performance data output of this plugin |
+| SkipUnknown | SwitchParameter | false | False | Allows to set Unknown partitions to Ok in case no metrics could be loaded. |
+| Verbosity | Int32 | false | 0 | Changes the behavior of the plugin output which check states are printed: 0 (default): Only service checks/packages with state not OK will be printed 1: Only services with not OK will be printed including OK checks of affected check packages including Package config 2: Everything will be printed regardless of the check state |
 
 ## Examples
 

--- a/plugins/Invoke-IcingaCheckUsedPartitionSpace.psm1
+++ b/plugins/Invoke-IcingaCheckUsedPartitionSpace.psm1
@@ -1,136 +1,159 @@
 <#
 .SYNOPSIS
-   Checks how much space on a partition is used.
+    Checks how much space on a partition is used.
 .DESCRIPTION
-   Invoke-IcingaCheckUsedPartition returns either 'OK', 'WARNING' or 'CRITICAL', based on the thresholds set.
-   e.g 'C:' is at 8% usage, WARNING is set to 60, CRITICAL is set to 80. In this case the check will return OK.
+    Invoke-IcingaCheckUsedPartition returns either 'OK', 'WARNING' or 'CRITICAL', based on the thresholds set.
+    e.g 'C:' is at 8% usage, WARNING is set to 60, CRITICAL is set to 80. In this case the check will return OK.
 
-   The plugin will return `UNKNOWN` in case partition data (size and free space) can not be fetched. This is
-   normally happening in case the user the plugin is running with does not have permissions to fetch this
-   specific partition data.
+    The plugin will return `UNKNOWN` in case partition data (size and free space) can not be fetched. This is
+    normally happening in case the user the plugin is running with does not have permissions to fetch this
+    specific partition data.
 
-   More Information on https://github.com/Icinga/icinga-powershell-plugins
+    More Information on https://github.com/Icinga/icinga-powershell-plugins
 .FUNCTIONALITY
-   This module is intended to be used to check how much usage there is on an partition.
-   Based on the thresholds set the status will change between 'OK', 'WARNING' or 'CRITICAL'. The function will return one of these given codes.
+    This module is intended to be used to check how much usage there is on an partition.
+    Based on the thresholds set the status will change between 'OK', 'WARNING' or 'CRITICAL'. The function will return one of these given codes.
 
-   The plugin will return `UNKNOWN` in case partition data (size and free space) can not be fetched. This is
-   normally happening in case the user the plugin is running with does not have permissions to fetch this
-   specific partition data.
+    The plugin will return `UNKNOWN` in case partition data (size and free space) can not be fetched. This is
+    normally happening in case the user the plugin is running with does not have permissions to fetch this
+    specific partition data.
 .ROLE
-   ### WMI Permissions
+    ### WMI Permissions
 
-   * Root\Cimv2
+    * Root\Cimv2
 
-   ### Performance Counter
+    ### Performance Counter
 
-   * LogicalDisk(*)\% free space
+    * LogicalDisk(*)\% free space
 .EXAMPLE
-   PS>Invoke-IcingaCheckUsedPartitionSpace -Warning 60 -Critical 80
-   [OK]: Check package "Used Partition Space" is [OK]
-   | 'Partition C'=8,06204986572266%;60;;0;100 'Partition D'=12,06204736572266%;60;;0;100 'Partition K'=19,062047896572266%;60;;0;100
+    PS>Invoke-IcingaCheckUsedPartitionSpace -Warning 60 -Critical 80
+    [OK]: Check package "Used Partition Space" is [OK]
+    | 'Partition C'=8,06204986572266%;60;;0;100 'Partition D'=12,06204736572266%;60;;0;100 'Partition K'=19,062047896572266%;60;;0;100
 .EXAMPLE
-   PS>Invoke-IcingaCheckUsedPartitionSpace -Warning 60 -Critical 80 -Exclude "C:\"
-   [OK]: Check package "Used Partition Space" is [OK]
-   | 'Partition D'=12,06204736572266%;60;;0;100 'Partition K'=19,062047896572266%;60;;0;100
+    PS>Invoke-IcingaCheckUsedPartitionSpace -Warning 60 -Critical 80 -Exclude "C:\"
+    [OK]: Check package "Used Partition Space" is [OK]
+    | 'Partition D'=12,06204736572266%;60;;0;100 'Partition K'=19,062047896572266%;60;;0;100
 .EXAMPLE
-   PS>Invoke-IcingaCheckUsedPartitionSpace -Warning 60 -Critical 80 -Include "C:\"
-   [OK]: Check package "Used Partition Space" is [OK]
-   | 'Partition C'=8,06204986572266%;60;;0;100
+    PS>Invoke-IcingaCheckUsedPartitionSpace -Warning 60 -Critical 80 -Include "C:\"
+    [OK]: Check package "Used Partition Space" is [OK]
+    | 'Partition C'=8,06204986572266%;60;;0;100
 .PARAMETER Warning
-   Used to specify a Warning threshold. In this case an integer value.
+    Used to specify a Warning threshold. In this case an integer value.
 .PARAMETER Critical
-   Used to specify a Critical threshold. In this case an integer value.
+    Used to specify a Critical threshold. In this case an integer value.
 .PARAMETER Exclude
-   Used to specify an array of partitions to be excluded.
-   e.g. 'C:\','D:\'
+    Used to specify an array of partitions to be excluded.
+    e.g. 'C:\','D:\'
 .PARAMETER Include
-   Used to specify an array of partitions to be included. If not set, the check expects that all not excluded partitions should be checked.
-   e.g. 'C:\','D:\'
+    Used to specify an array of partitions to be included. If not set, the check expects that all not excluded partitions should be checked.
+    e.g. 'C:\','D:\'
+.PARAMETER IgnoreEmptyChecks
+    Overrides the default behaviour of the plugin in case no check element is left for being checked (if all elements are filtered out for example).
+    Instead of returning `Unknown` the plugin will return `Ok` instead if this argument is set.
+.PARAMETER SkipUnknown
+    Allows to set Unknown partitions to Ok in case no metrics could be loaded.
+.PARAMETER NoPerfData
+    Disables the performance data output of this plugin
+.PARAMETER Verbosity
+    Changes the behavior of the plugin output which check states are printed:
+    0 (default): Only service checks/packages with state not OK will be printed
+    1: Only services with not OK will be printed including OK checks of affected check packages including Package config
+    2: Everything will be printed regardless of the check state
 .INPUTS
-   System.String
+    System.String
 .OUTPUTS
-   System.String
+    System.String
 .LINK
-   https://github.com/Icinga/icinga-powershell-plugins
+    https://github.com/Icinga/icinga-powershell-plugins
 .NOTES
 #>
 
 function Invoke-IcingaCheckUsedPartitionSpace()
 {
-   param(
-      $Warning            = $null,
-      $Critical           = $null,
-      [array]$Include     = @(),
-      [array]$Exclude     = @(),
-      [switch]$NoPerfData,
-      [ValidateSet(0, 1, 2, 3)]
-      [int]$Verbosity     = 0
-   );
+    param(
+        $Warning                   = $null,
+        $Critical                  = $null,
+        [array]$Include            = @(),
+        [array]$Exclude            = @(),
+        [switch]$IgnoreEmptyChecks = $FALSE,
+        [switch]$NoPerfData        = $FALSE,
+        [switch]$SkipUnknown       = $FALSE,
+        [ValidateSet(0, 1, 2, 3)]
+        [int]$Verbosity            = 0
+    );
 
-   $DiskFree        = Get-IcingaDiskPartitions;
-   $DiskPackage     = New-IcingaCheckPackage -Name 'Used Partition Space' -OperatorAnd -Verbose $Verbosity;
-   $DiskBytePackage = New-IcingaCheckPackage -Name 'Used Partition Space in Bytes' -Verbose $Verbosity -Hidden;
+    $DiskFree        = Get-IcingaDiskPartitions;
+    $DiskPackage     = New-IcingaCheckPackage -Name 'Used Partition Space' -OperatorAnd -Verbose $Verbosity -IgnoreEmptyPackage:$IgnoreEmptyChecks;
+    $DiskBytePackage = New-IcingaCheckPackage -Name 'Used Partition Space in Bytes' -Verbose $Verbosity -IgnoreEmptyPackage:$IgnoreEmptyChecks -Hidden;
 
-   foreach ($Letter in $DiskFree.Keys) {
-      if ($Include.Count -ne 0) {
-         $Include = $Include.trim(' :/\');
-         if (-Not ($Include.Contains($Letter))) {
-               continue;
-         }
-      }
+    foreach ($Letter in $DiskFree.Keys) {
+        if ($Include.Count -ne 0) {
+            $Include = $Include.trim(' :/\');
+            if (-Not ($Include.Contains($Letter))) {
+                continue;
+            }
+        }
 
-      if ($Exclude.Count -ne 0) {
-         $Exclude = $Exclude.trim(' :/\');
-         if ($Exclude.Contains($Letter)) {
-               continue;
-         }
-      }
+        if ($Exclude.Count -ne 0) {
+            $Exclude = $Exclude.trim(' :/\');
+            if ($Exclude.Contains($Letter)) {
+                continue;
+            }
+        }
 
-      $SetUnknown = $FALSE;
+        $SetUnknown = $FALSE;
+        $CheckName  = [string]::Format('Partition {0}', $Letter);
 
-      if ([string]::IsNullOrEmpty($DiskFree.([string]::Format($Letter))."Size") -Or [string]::IsNullOrEmpty($DiskFree.([string]::Format($Letter))."Free Space")) {
-         $SetUnknown = $TRUE;
-      }
+        $Unit               = Get-UnitPrefixIEC $DiskFree.([string]::Format($Letter))."Size";
+        $PerfUnit           = Get-UnitPrefixSI  $DiskFree.([string]::Format($Letter))."Size";
+        $FreeSpace          = (100-($DiskFree.([string]::Format($Letter))."Free Space"));
+        $Bytes              = [math]::Round(($DiskFree.([string]::Format($Letter))."Size") * $FreeSpace / 100);
+        $ByteString         = [string]::Format('{0}B', $Bytes);
+        $ByteValueConverted = Convert-Bytes -Value $ByteString -Unit $Unit;
+        $DiskSizeBytes      = $DiskFree[$Letter]['Size'];
 
-      $Unit               = Get-UnitPrefixIEC $DiskFree.([string]::Format($Letter))."Size";
-      $PerfUnit           = Get-UnitPrefixSI  $DiskFree.([string]::Format($Letter))."Size";
-      $Bytes              = [math]::Round(($DiskFree.([string]::Format($Letter))."Size") * (100-($DiskFree.([string]::Format($Letter))."Free Space")) / 100);
-      $ByteString         = [string]::Format('{0}B', $Bytes);
-      $ByteValueConverted = Convert-Bytes -Value $ByteString -Unit $Unit;
-      $DiskSizeBytes      = $DiskFree[$Letter]['Size'];
-      if ($null -eq $DiskSizeBytes) {
-         $DiskSizeBytes = 0;
-      }
-      $DiskSize           = Convert-Bytes -Value ([string]::Format('{0}B', $DiskSizeBytes)) -Unit $Unit;
-      $DiskTotalWarning   = $null;
-      $DiskTotalCritical  = $null;
+        if ([string]::IsNullOrEmpty($DiskFree.([string]::Format($Letter))."Size") -Or [string]::IsNullOrEmpty($DiskFree.([string]::Format($Letter))."Free Space")) {
+            $SetUnknown = $TRUE;
+            $CheckName  = [string]::Format('Partition {0}: No data available for calculation', $Letter);
+            $FreeSpace  = $null;
+        }
 
-      if ($null -ne $Warning -And $DiskSize.Value -ne 0) {
-         $DiskTotalWarning = $DiskSize.Value / 100 * $Warning;
-      }
-      if ($null -ne $Critical -And $DiskSize.Value -ne 0) {
-         $DiskTotalCritical = $DiskSize.Value / 100 * $Critical;
-      }
+        if ($null -eq $DiskSizeBytes) {
+            $DiskSizeBytes = 0;
+        }
+        $DiskSize           = Convert-Bytes -Value ([string]::Format('{0}B', $DiskSizeBytes)) -Unit $Unit;
+        $DiskTotalWarning   = $null;
+        $DiskTotalCritical  = $null;
 
-      $IcingaCheckByte = New-IcingaCheck -Name ([string]::Format( 'Used Space Partition {0}', $Letter )) -Value $ByteValueConverted.Value -Unit $PerfUnit -Minimum 0 -Maximum $DiskSize.Value;
-      if ($SetUnknown -eq $FALSE) {
-         $IcingaCheckByte.WarnOutOfRange($DiskTotalWarning).CritOutOfRange($DiskTotalCritical) | Out-Null;
-      } else {
-         $IcingaCheckByte.SetUnknown() | Out-Null;
-      }
-      $DiskBytePackage.AddCheck($IcingaCheckByte);
+        if ($null -ne $Warning -And $DiskSize.Value -ne 0) {
+            $DiskTotalWarning = $DiskSize.Value / 100 * $Warning;
+        }
+        if ($null -ne $Critical -And $DiskSize.Value -ne 0) {
+            $DiskTotalCritical = $DiskSize.Value / 100 * $Critical;
+        }
 
-      $IcingaCheck = New-IcingaCheck -Name ([string]::Format('Partition {0}', $Letter)) -Value (100-($DiskFree.([string]::Format($Letter))."Free Space")) -Unit '%';
-      if ($SetUnknown -eq $FALSE) {
-         $IcingaCheck.WarnOutOfRange($Warning).CritOutOfRange($Critical) | Out-Null;
-      } else {
-         $IcingaCheck.SetUnknown() | Out-Null;
-      }
-      $DiskPackage.AddCheck($IcingaCheck);
+        $IcingaCheckByte = New-IcingaCheck -Name ([string]::Format( 'Used Space Partition {0}', $Letter )) -Value $ByteValueConverted.Value -Unit $PerfUnit -Minimum 0 -Maximum $DiskSize.Value -NoPerfData:$SetUnknown;
+        if ($SetUnknown -eq $FALSE) {
+            $IcingaCheckByte.WarnOutOfRange($DiskTotalWarning).CritOutOfRange($DiskTotalCritical) | Out-Null;
+        } else {
+            if ($SkipUnknown -eq $FALSE) {
+                $IcingaCheck.SetUnknown() | Out-Null;
+            }
+        }
+        $DiskBytePackage.AddCheck($IcingaCheckByte);
 
-      $DiskPackage.AddCheck($DiskBytePackage);
-   }
+        $IcingaCheck = New-IcingaCheck -Name $CheckName -Value $FreeSpace -Unit '%' -NoPerfData:$SetUnknown;
+        if ($SetUnknown -eq $FALSE) {
+            $IcingaCheck.WarnOutOfRange($Warning).CritOutOfRange($Critical) | Out-Null;
+        } else {
+            if ($SkipUnknown -eq $FALSE) {
+                $IcingaCheck.SetUnknown() | Out-Null;
+            }
+        }
+        $DiskPackage.AddCheck($IcingaCheck);
 
-   return (New-IcingaCheckResult -Check $DiskPackage -NoPerfData $NoPerfData -Compile);
+        $DiskPackage.AddCheck($DiskBytePackage);
+    }
+
+    return (New-IcingaCheckResult -Check $DiskPackage -NoPerfData $NoPerfData -Compile);
 }


### PR DESCRIPTION
We should add support to ignore empty check packages in case we filtered all partitions out on the check. This might be required in certain scenarios and can be very helpful.

In addition it might be helpful to convert Unknown partition data to Ok for not causing false positives.