### PR TITLE
Feature: Adds support to ignore read only/offline disks on Invoke-IcingaCheckDiskHealth

### DIFF
--- a/doc/31-Changelog.md
+++ b/doc/31-Changelog.md
@@ -17,6 +17,7 @@ Released closed milestones can be found on [GitHub](https://github.com/Icinga/ic
 * [#74](https://github.com/Icinga/icinga-powershell-plugins/pull/74) Adds `avg. disk queue length` metric for monitoring and performance data to `Invoke-IcingaCheckDiskHealth`
 * [#78](https://github.com/Icinga/icinga-powershell-plugins/issues/78) Improves the documentation and output for `Invoke-IcingaCheckService` by adding metrics for all found services configured to run `Automatic` and adds service output on Verbosity 1 to show a list of all found services including their current state
 * [#85](https://github.com/Icinga/icinga-powershell-plugins/issues/85) Adds support on `Invoke-IcingaCheckUsedPartitionSpace` to ignore a `Unknown` in case all checks are filtered out. This will then return `Ok` instead if argument `-IgnoreEmptyChecks` is set. In addition you can now use `-SkipUnknown` which will transform an `Unknown` of partitions without data to `Ok`. Reworks [#84](https://github.com/Icinga/icinga-powershell-plugins/issues/84)
+* [#90](https://github.com/Icinga/icinga-powershell-plugins/issues/90) Adds support to ignore read only/offline disks on `Invoke-IcingaCheckDiskHealth`
 
 ### Bugfixes
 

--- a/doc/plugins/20-Invoke-IcingaCheckDiskHealth.md
+++ b/doc/plugins/20-Invoke-IcingaCheckDiskHealth.md
@@ -61,6 +61,8 @@ To execute this plugin you will require to grant the following user permissions.
 | DiskAvgReadSecCritical | Object | false |  | Critical threshold for avg. Disk sec/Read is the average time, in seconds, of a read of data from the disk. If the threshold values are not in seconds, please enter a unit such as (ms, s, m, h, ...) |
 | DiskAvgWriteSecWarning | Object | false |  | Warning threshold for Avg. Disk sec/Write is the average time, in seconds, of a write of data to the disk. If the threshold values are not in seconds, please enter a unit such as (ms, s, m, h, ...) |
 | DiskAvgWriteSecCritical | Object | false |  | Critical threshold for Avg. Disk sec/Write is the average time, in seconds, of a write of data to the disk. If the threshold values are not in seconds, please enter a unit such as (ms, s, m, h, ...) |
+| IgnoreOfflineDisks | SwitchParameter | false | False | Ignores any disk which is having the state `Offline` and returns `Ok` instead of `Warning` for this specific state |
+| IgnoreReadOnlyDisks | SwitchParameter | false | False | Ignores any disk which is having the state `Read Only` and returns `Ok` instead of `Warning` for this specific state |
 | CheckLogicalOnly | SwitchParameter | false | False | Set this to include only disks that have drive letters like C:, D:, ..., assigned to them. Can be combined with include/exclude filters |
 | NoPerfData | SwitchParameter | false | False |  |
 | Verbosity | Int32 | false | 0 |  |


### PR DESCRIPTION
Adds two new argumengs to `Invoke-IcingaCheckDiskHealth`, `-IgnoreOfflineDisks` and `-IgnoreReadOnlyDisks` which will ignore disks which are either in the `Offline` or `Read Only` state and returns `Ok` instead of `Warning` once the new flags are set.