### PR TITLE
Doc: Adds documentation for monitoring avg. load on all cores for CPU plugin

### DIFF
--- a/doc/plugins/04-Invoke-IcingaCheckCPU.md
+++ b/doc/plugins/04-Invoke-IcingaCheckCPU.md
@@ -27,7 +27,7 @@ To execute this plugin you will require to grant the following user permissions.
 | ---      | ---  | ---      | ---     | ---         |
 | Warning | Object | false |  | Used to specify a Warning threshold. In this case an integer value. |
 | Critical | Object | false |  | Used to specify a Critical threshold. In this case an integer value. |
-| Core | String | false | * | Used to specify a single core to check for. |
+| Core | String | false | * | Used to specify a single core to check for. For the average load across all cores use `_Total` |
 | NoPerfData | SwitchParameter | false | False |  |
 | Verbosity | Int32 | false | 0 |  |
 

--- a/plugins/Invoke-IcingaCheckCPU.psm1
+++ b/plugins/Invoke-IcingaCheckCPU.psm1
@@ -29,7 +29,7 @@
 .PARAMETER Critical
     Used to specify a Critical threshold. In this case an integer value.
 .PARAMETER Core
-    Used to specify a single core to check for.
+    Used to specify a single core to check for. For the average load across all cores use `_Total`
 .INPUTS
     System.String
 .OUTPUTS


### PR DESCRIPTION
Adds documentation on how to monitor avg. CPU load on all cores only.

#93 