### PR TITLE
Fix: Invoke-IcingaCheckScheduledTask returns invalid perf data output

### DIFF
--- a/doc/31-Changelog.md
+++ b/doc/31-Changelog.md
@@ -24,6 +24,7 @@ Released closed milestones can be found on [GitHub](https://github.com/Icinga/ic
 * [#77](https://github.com/Icinga/icinga-powershell-plugins/issues/77) Fix wrong filtering for EventIds for `Invoke-IcingaCheckEventLog` and improve the output by adding the EventLog messages on severity 1. In addition we now allow the filtering for message sources and increase performance by fetching EventLog data for new checks from the last 2 hours only
 * [#79](https://github.com/Icinga/icinga-powershell-plugins/issues/79) Fixes service check to exclude provided service names in case they contain the wildcard symbol '*' which causes the check to always return unknown
 * [#86](https://github.com/Icinga/icinga-powershell-plugins/pull/86) Fixes `Get-IcingaCPUCount` returns wrong count on empty arguments
+* [#97](https://github.com/Icinga/icinga-powershell-plugins/issues/97), [#98](https://github.com/Icinga/icinga-powershell-plugins/pull/98) Fixes invalid performance data output for `Invoke-IcingaCheckScheduledTask`
 
 ## 1.2.0 (2020-08-28)
 

--- a/plugins/Invoke-IcingaCheckScheduledTask.psm1
+++ b/plugins/Invoke-IcingaCheckScheduledTask.psm1
@@ -68,8 +68,8 @@ function Invoke-IcingaCheckScheduledTask()
             } else {
                 $CheckPackage.AddCheck(
                     (
-                        New-IcingaCheck -Name ([string]::Format('{0} ({1})', $task.TaskName, $task.TaskPath)) -Value $task.State
-                    ).CritIfNotMatch($State)
+                        New-IcingaCheck -Name ([string]::Format('{0} ({1})', $task.TaskName, $task.TaskPath)) -Value ($ProviderEnums.ScheduledTaskStatus[[string]$task.State]) -Translation $ProviderEnums.ScheduledTaskName
+                    ).CritIfNotMatch($ProviderEnums.ScheduledTaskStatus[$State])
                 )
             }
         }

--- a/provider/enums/Icinga_ProviderEnums.psm1
+++ b/provider/enums/Icinga_ProviderEnums.psm1
@@ -763,6 +763,26 @@
     'Disabled'  = 4;
 }
 
+<##################################################################################################
+################# /lib/provider/tasks #############################################################
+##################################################################################################>
+
+[hashtable]$ScheduledTaskStatus = @{
+    'Unknown'  = 0;
+    'Disabled' = 1;
+    'Queued'   = 2;
+    'Ready'    = 3;
+    'Running'  = 4;
+}
+
+[hashtable]$ScheduledTaskName = @{
+    0 = 'Unknown';
+    1 = 'Disabled';
+    2 = 'Queued';
+    3 = 'Ready';
+    4 = 'Running';
+}
+
 [hashtable]$TimeSyncStatus = @{
     'NoLeapWarning'       = 0;
     'PositiveLeapSecond'  = 1;
@@ -878,6 +898,9 @@
     ServiceStatus                  = $ServiceStatus;
     ServiceStatusName              = $ServiceStatusName;
     ServiceStartupType             = $ServiceStartupType;
+    #/lib/provider/tasks
+    ScheduledTaskStatus            = $ScheduledTaskStatus;
+    ScheduledTaskName              = $ScheduledTaskName;
     #/lib/provider/NtpChecks
     TimeSyncStatus                 = $TimeSyncStatus;
     TimeSyncStatusName             = $TimeSyncStatusName;


### PR DESCRIPTION
Fixes `Invoke-IcingaCheckScheduledTask` performance data output by using integer states instead of the string state names.