### PR TITLE
Feature: Changed Invoke-IcingaCheckScheduledTask to support multi States

### DIFF
--- a/doc/30-Upgrading-Plugins.md
+++ b/doc/30-Upgrading-Plugins.md
@@ -8,9 +8,9 @@ For upgrading plugins, please have a look on the [installation docs](02-installa
 
 ## Upgrading to v1.3.0 (2020-12-01)
 
-### Plugin Argument Changes <span style="color:#F6BE00">(Breaking Changes)
+### Plugin Argument Changes <span style="color:#F6BE00">(Breaking Changes)</span>
 
-The following plugins received modifications to their existing arguments. Please keep in mind that updating to this version of the Icinga PowerShell Plugins, you **must** update your configuration to ensure everything is running properly **and** update all plugins on all systems at once.
+The following plugins received modifications to their existing arguments. Please keep in mind that updating to this version of the Icinga PowerShell Plugins, you **must** update your configuration to ensure everything is running properly **and** update all plugins on all systems. As for the Icinga Director, you have to import the new basket for these plugins to apply the configuration. How ever, <span style="color:#F6BE00">current values assigned to these arguments will no longer apply and have to be reconfigured!</span>
 
 #### Invoke-IcingaCheckScheduledTask
 

--- a/doc/31-Changelog.md
+++ b/doc/31-Changelog.md
@@ -18,6 +18,10 @@ This release adds the following new plugin:
 * [Invoke-IcingaCheckNetworkInterface](https://icinga.com/docs/windows/latest/plugins/doc/plugins/21-Invoke-IcingaCheckNetworkInterface/): Checks availability, state and Usage of Network interfaces and Interface Teams
 * [Invoke-IcingaCheckStoragePool](https://icinga.com/docs/windows/latest/plugins/doc/plugins/21-Invoke-IcingaCheckStoragePool/): Checks availability, utilization and state of a StoragePool
 
+### Breaking changes
+
+If you are going to install this plugin release, please have a look on the [upgrading docs](https://icinga.com/docs/windows/latest/plugins/doc/30-Upgrading-Plugins/) to not run into issues!
+
 ### Enhancements
 
 * [#61](https://github.com/Icinga/icinga-powershell-plugins/issues/61) Adds exception handling in case permissions to access Windows Updates are missing on the system
@@ -26,6 +30,7 @@ This release adds the following new plugin:
 * [#78](https://github.com/Icinga/icinga-powershell-plugins/issues/78) Improves the documentation and output for `Invoke-IcingaCheckService` by adding metrics for all found services configured to run `Automatic` and adds service output on Verbosity 1 to show a list of all found services including their current state
 * [#85](https://github.com/Icinga/icinga-powershell-plugins/issues/85) Adds support on `Invoke-IcingaCheckUsedPartitionSpace` to ignore a `Unknown` in case all checks are filtered out. This will then return `Ok` instead if argument `-IgnoreEmptyChecks` is set. In addition you can now use `-SkipUnknown` which will transform an `Unknown` of partitions without data to `Ok`. Reworks [#84](https://github.com/Icinga/icinga-powershell-plugins/issues/84)
 * [#90](https://github.com/Icinga/icinga-powershell-plugins/issues/90) Adds support to ignore read only/offline disks on `Invoke-IcingaCheckDiskHealth`
+* [#101](https://github.com/Icinga/icinga-powershell-plugins/pull/101) Improves `Invoke-IcingaCheckScheduledTask` by changing the `State` argument from `String` to `Array`, allowing the comparison against multiple states. **Important:** Please have a look on the [upgrading docs!](https://icinga.com/docs/windows/latest/plugins/doc/30-Upgrading-Plugins/)
 * [#104](https://github.com/Icinga/icinga-powershell-plugins/pull/104) Adds plugin configuration files for Icinga Director and Icinga 2 within the [config directory](https://github.com/Icinga/icinga-powershell-plugins/tree/master/config)
 
 ### Bugfixes


### PR DESCRIPTION
Improves `Invoke-IcingaCheckScheduledTask` by changing the `State` argument from `String` to `Array`, allowing the comparison against multiple states. **Important:** Please have a look on the [upgrading docs!](https://icinga.com/docs/windows/latest/plugins/doc/30-Upgrading-Plugins/)