### PR TITLE
Fix: Adds exception handling for checksum plugin

### DIFF
--- a/doc/31-Changelog.md
+++ b/doc/31-Changelog.md
@@ -32,6 +32,7 @@ If you are going to install this plugin release, please have a look on the [upgr
 * [#90](https://github.com/Icinga/icinga-powershell-plugins/issues/90) Adds support to ignore read only/offline disks on `Invoke-IcingaCheckDiskHealth`
 * [#101](https://github.com/Icinga/icinga-powershell-plugins/pull/101) Improves `Invoke-IcingaCheckScheduledTask` by changing the `State` argument from `String` to `Array`, allowing the comparison against multiple states. **Important:** Please have a look on the [upgrading docs!](https://icinga.com/docs/windows/latest/plugins/doc/30-Upgrading-Plugins/)
 * [#104](https://github.com/Icinga/icinga-powershell-plugins/pull/104) Adds plugin configuration files for Icinga Director and Icinga 2 within the [config directory](https://github.com/Icinga/icinga-powershell-plugins/tree/master/config)
+* [#109](https://github.com/Icinga/icinga-powershell-plugins/pull/109) Adds exception handling in case `-Path` argument is not set or not directing a file (including invalid path)
 
 ### Bugfixes
 

--- a/plugins/Invoke-IcingaCheckCheckSum.psm1
+++ b/plugins/Invoke-IcingaCheckCheckSum.psm1
@@ -1,61 +1,69 @@
 <#
 .SYNOPSIS
-   Checks hash against filehash of a file
+    Checks hash against file hash of a file
 .DESCRIPTION
-   Invoke-IcingaCheckCheckSum returns either 'OK' or 'CRITICAL', whether the check matches or not.
+    Invoke-IcingaCheckCheckSum returns either 'OK' or 'CRITICAL', whether the check matches or not.
 
-   More Information on https://github.com/Icinga/icinga-powershell-plugins
+    More Information on https://github.com/Icinga/icinga-powershell-plugins
 .FUNCTIONALITY
-   This module is intended to be used to check a hash against a filehash of a file, to determine whether changes have occured.
-   Based on the match result the status will change between 'OK' or 'CRITICAL'. The function will return one of these given codes.
+    This module is intended to be used to check a hash against a file hash of a file, to determine whether changes have occurred.
+    Based on the match result the status will change between 'OK' or 'CRITICAL'. The function will return one of these given codes.
 .EXAMPLE
-   PS> Invoke-IcingaCheckCheckSum -Path "C:\Users\Icinga\Downloads\test.txt"
-   [OK] CheckSum C:\Users\Icinga\Downloads\test.txt is 008FB84A017F5DFDAF038DB2FDD6934E6E5D9CD3C7AACE2F2168D7D93AF51E4B
+    PS> Invoke-IcingaCheckCheckSum -Path "C:\Users\Icinga\Downloads\test.txt"
+    [OK] CheckSum C:\Users\Icinga\Downloads\test.txt is 008FB84A017F5DFDAF038DB2FDD6934E6E5D9CD3C7AACE2F2168D7D93AF51E4B
 .EXAMPLE
-   PS> Invoke-IcingaCheckCheckSum -Path "C:\Users\Icinga\Downloads\test.txt" -Hash 008FB84A017F5DFDAF038DB2FDD6934E6E5D9CD3C7AACE2F2168D7D93AF51E4B
-   [OK] CheckSum C:\Users\Icinga\Downloads\test.txt is 008FB84A017F5DFDAF038DB2FDD6934E6E5D9CD3C7AACE2F2168D7D93AF51E4B|
+    PS> Invoke-IcingaCheckCheckSum -Path "C:\Users\Icinga\Downloads\test.txt" -Hash 008FB84A017F5DFDAF038DB2FDD6934E6E5D9CD3C7AACE2F2168D7D93AF51E4B
+    [OK] CheckSum C:\Users\Icinga\Downloads\test.txt is 008FB84A017F5DFDAF038DB2FDD6934E6E5D9CD3C7AACE2F2168D7D93AF51E4B|
 .EXAMPLE
-   PS> Invoke-IcingaCheckCheckSum -Path "C:\Users\Icinga\Downloads\test.txt" -Hash 008FB84A017F5DFDAF038DB2FDD6934E6E5D
-   [CRITICAL] CheckSum C:\Users\Icinga\Downloads\test.txt 008FB84A017F5DFDAF038DB2FDD6934E6E5D9CD3C7AACE2F2168D7D93AF51E4B is not matching 008FB84A017F5DFDAF038DB2FDD6934E6E5D
+    PS> Invoke-IcingaCheckCheckSum -Path "C:\Users\Icinga\Downloads\test.txt" -Hash 008FB84A017F5DFDAF038DB2FDD6934E6E5D
+    [CRITICAL] CheckSum C:\Users\Icinga\Downloads\test.txt 008FB84A017F5DFDAF038DB2FDD6934E6E5D9CD3C7AACE2F2168D7D93AF51E4B is not matching 008FB84A017F5DFDAF038DB2FDD6934E6E5D
 .PARAMETER WarningBytes
-   Used to specify a string to the path of a file, which will be checked.
+    Used to specify a string to the path of a file, which will be checked.
 
-   The string has to be like "C:\Users\Icinga\test.txt"
+    The string has to be like "C:\Users\Icinga\test.txt"
 
 .PARAMETER Algorithm
-   Used to specify a string, which contains the algorithm to be used.
+    Used to specify a string, which contains the algorithm to be used.
 
-   Allowed algorithms: 'SHA1', 'SHA256', 'SHA384', 'SHA512', 'MD5'
+    Allowed algorithms: 'SHA1', 'SHA256', 'SHA384', 'SHA512', 'MD5'
 
 .INPUTS
-   System.String
+    System.String
 
 .OUTPUTS
-   System.String
+    System.String
 
 .LINK
-   https://github.com/Icinga/icinga-powershell-plugins
+    https://github.com/Icinga/icinga-powershell-plugins
 .NOTES
 #>
 
 function Invoke-IcingaCheckCheckSum()
 {
-   param(
-      [string]$Path       = $null,
-      [ValidateSet('SHA1', 'SHA256', 'SHA384', 'SHA512', 'MD5')]
-      [string]$Algorithm  = 'SHA256',
-      [string]$Hash       = $null,
-      [switch]$NoPerfData,
-      [ValidateSet(0, 1, 2, 3)]
-      [int]$Verbosity     = 0
-   );
+    param (
+        [string]$Path       = $null,
+        [ValidateSet('SHA1', 'SHA256', 'SHA384', 'SHA512', 'MD5')]
+        [string]$Algorithm  = 'SHA256',
+        [string]$Hash       = $null,
+        [switch]$NoPerfData,
+        [ValidateSet(0, 1, 2, 3)]
+        [int]$Verbosity     = 0
+    );
 
-   [string]$FileHash = (Get-FileHash $Path -Algorithm $Algorithm).Hash
-   $CheckSumCheck    = New-IcingaCheck -Name "CheckSum $Path" -Value $FileHash;
+    if ([string]::IsNullOrEmpty($Path)) {
+        Exit-IcingaThrowException -Force -CustomMessage 'Unset argument "-Path"' -ExceptionType 'Configuration' -ExceptionThrown $IcingaExceptions.Configuration.PluginArgumentMissing;
+    }
 
-   If(([string]::IsNullOrEmpty($Hash)) -eq $FALSE){
-      $CheckSumCheck.CritIfNotMatch($Hash) | Out-Null;
-   }
+    if ((Test-Path $Path) -eq $FALSE -Or (Get-Item $Path) -Is [System.IO.DirectoryInfo]) {
+        Exit-IcingaThrowException -Force -CustomMessage '"-Path" is not directing to a file' -ExceptionType 'Configuration' -ExceptionThrown $IcingaExceptions.Configuration.PluginArgumentConflict;
+    }
 
-   return (New-IcingaCheckresult -Check $CheckSumCheck -NoPerfData $NoPerfData -Compile);
+    [string]$FileHash = (Get-FileHash $Path -Algorithm $Algorithm).Hash
+    $CheckSumCheck    = New-IcingaCheck -Name "CheckSum $Path" -Value $FileHash;
+
+    If (([string]::IsNullOrEmpty($Hash)) -eq $FALSE) {
+        $CheckSumCheck.CritIfNotMatch($Hash) | Out-Null;
+    }
+
+    return (New-IcingaCheckResult -Check $CheckSumCheck -NoPerfData $NoPerfData -Compile);
 }


### PR DESCRIPTION
Adds exception handling in case `-Path` argument is not set or not directing a file (including invalid path)