### PR TITLE
Fix: Eventlog throwing unknown on valid arguments

### DIFF
--- a/doc/31-Changelog.md
+++ b/doc/31-Changelog.md
@@ -42,6 +42,7 @@ If you are going to install this plugin release, please have a look on the [upgr
 * [#86](https://github.com/Icinga/icinga-powershell-plugins/pull/86) Fixes `Get-IcingaCPUCount` returns wrong count on empty arguments
 * [#97](https://github.com/Icinga/icinga-powershell-plugins/issues/97), [#98](https://github.com/Icinga/icinga-powershell-plugins/pull/98) Fixes invalid performance data output for `Invoke-IcingaCheckScheduledTask`
 * [#102](https://github.com/Icinga/icinga-powershell-plugins/pull/102), [#103](https://github.com/Icinga/icinga-powershell-plugins/pull/103) Fixes `Invoke-IcingaCheckNetworkInterface` plugins arguments being too long for Icinga Director
+* [#110](https://github.com/Icinga/icinga-powershell-plugins/pull/110) Fixes `Invoke-IcingaCheckEventLog` plugin throwing an unknown for valid arguments
 
 ## 1.2.0 (2020-08-28)
 

--- a/provider/eventlog/Get-IcingaEventLog.psm1
+++ b/provider/eventlog/Get-IcingaEventLog.psm1
@@ -44,10 +44,10 @@ function Get-IcingaEventLog()
         $After = [datetime]::Now.Subtract([TimeSpan]::FromHours(2));
     }
     
-    if ($null -ne $IncludeUsername) {
+    if ($null -ne $IncludeUsername -And $IncludeUsername.Count -ne 0) {
         $EventLogArguments.Add('UserName', $IncludeUsername);
     }
-    if ($null -ne $IncludeEntryType) {
+    if ($null -ne $IncludeEntryType -And $IncludeEntryType.Count -ne 0) {
         $EventLogArguments.Add('EntryType', $IncludeEntryType);
     }
     if ($null -ne $After) {


### PR DESCRIPTION
Fixes EventLog plugin throwing an unknown for valid arguments:

```powershell
icinga { Invoke-IcingaCheckEventlog '-Warning' '5' '-Critical' '10' '-LogName' 'Application' '-IncludeEventId' '@()' '-ExcludeEventId' '@()' '-IncludeUsername @() -IncludeEntryType @() -ExcludeEntryType @() -IncludeMessage @() -ExcludeMessage @() -IncludeSource @() -ExcludeSource @() }
```

```text
[UNKNOWN]: Icinga Invalid Input Error was thrown: EventLog

Failed to fetch EventLog information. Please check your inputs for EntryTypes and other categories and try again.
```