### PR TITLE
Fix: Service Check crashes on automatic service not running

### DIFF
--- a/doc/31-Changelog.md
+++ b/doc/31-Changelog.md
@@ -16,6 +16,7 @@ Released closed milestones can be found on [GitHub](https://github.com/Icinga/ic
 ### Bugfixes
 
 * [#123](https://github.com/Icinga/icinga-powershell-plugins/pull/123) Fixes wrong documented user group for accessing Performance Counter objects which should be `Performance Monitor Users`
+* [#124](https://github.com/Icinga/icinga-powershell-plugins/pull/124) Fixes crash on `Invoke-IcingaCheckService` if an automatic service is not running
 
 ## 1.3.0 (2020-12-01)
 

--- a/plugins/Invoke-IcingaCheckService.psm1
+++ b/plugins/Invoke-IcingaCheckService.psm1
@@ -99,7 +99,7 @@ function Invoke-IcingaCheckService()
                 continue;
             }
 
-            # Service is not running bug the ExitCode is 0 -> this is fine and should not raise a critical
+            # Service is not running but the ExitCode is 0 -> this is fine and should not raise a critical
             if ($autoservice.configuration.ExitCode -eq 0) {
                 $ServicesPackage.AddCheck(
                     (New-IcingaWindowsServiceCheckObject -Status 'Stopped' -Service $autoservice -NoPerfData)
@@ -109,7 +109,7 @@ function Invoke-IcingaCheckService()
 
             # Services which should be running, but are not
             $ServicesPackage.AddCheck(
-                (New-IcingaWindowsServiceCheckObject -Status 'Running' -Service $FetchedServices[$services] -NoPerfData)
+                (New-IcingaWindowsServiceCheckObject -Status 'Running' -Service $autoservice -NoPerfData)
             );
         }
     } else {


### PR DESCRIPTION
Fixes #121

There was an error on the `-Service` argument while creating the service check object for services which should run automatically.