### PR TITLE
Fix: Prefer startup type of services fetching over WMI instead of Get-Services

### DIFF
--- a/doc/31-Changelog.md
+++ b/doc/31-Changelog.md
@@ -17,6 +17,7 @@ Released closed milestones can be found on [GitHub](https://github.com/Icinga/ic
 
 * [#123](https://github.com/Icinga/icinga-powershell-plugins/pull/123) Fixes wrong documented user group for accessing Performance Counter objects which should be `Performance Monitor Users`
 * [#124](https://github.com/Icinga/icinga-powershell-plugins/pull/124) Fixes crash on `Invoke-IcingaCheckService` if an automatic service is not running
+* [#126](https://github.com/Icinga/icinga-powershell-plugins/pull/126) Fixes code base for `Invoke-IcingaCheckService` by preferring to fetch the startup type of services by using WMI instead of `Get-Services`, as the result of `Get-Services` might be empty in some cases
 
 ## 1.3.0 (2020-12-01)
 

--- a/provider/enums/Icinga_ProviderEnums.psm1
+++ b/provider/enums/Icinga_ProviderEnums.psm1
@@ -863,9 +863,30 @@
 }
 
 [hashtable]$ServiceStartupType = @{
+    'Boot'      = 0;
+    'System'    = 1;
     'Automatic' = 2;
     'Manual'    = 3;
     'Disabled'  = 4;
+    'Unknown'   = 5; # Custom
+}
+
+[hashtable]$ServiceStartupTypeName = @{
+    0 = 'Boot';
+    1 = 'System';
+    2 = 'Automatic';
+    3 = 'Manual';
+    4 = 'Disabled';
+    5 = 'Unknown'; # Custom
+}
+
+[hashtable]$ServiceWmiStartupType = @{
+    'Boot'     = 0;
+    'System'   = 1;
+    'Auto'     = 2;
+    'Manual'   = 3;
+    'Disabled' = 4;
+    'Unknown'  = 5; # Custom
 }
 
 <##################################################################################################
@@ -1013,6 +1034,8 @@
     ServiceStatus                  = $ServiceStatus;
     ServiceStatusName              = $ServiceStatusName;
     ServiceStartupType             = $ServiceStartupType;
+    ServiceStartupTypeName         = $ServiceStartupTypeName;
+    ServiceWmiStartupType          = $ServiceWmiStartupType;
     #/lib/provider/tasks
     ScheduledTaskStatus            = $ScheduledTaskStatus;
     ScheduledTaskName              = $ScheduledTaskName;

--- a/provider/services/Icinga_ProviderServices.psm1
+++ b/provider/services/Icinga_ProviderServices.psm1
@@ -26,6 +26,8 @@ function Get-IcingaServices()
         [array]$DependingServices = $null;
         $ServiceExitCode          = 0;
         [string]$ServiceUser      = '';
+        [int]$StartModeId         = 5;
+        [string]$StartMode        = 'Unknown';
 
         if ($Exclude -contains $service.ServiceName) {
             continue;
@@ -35,6 +37,10 @@ function Get-IcingaServices()
             if ($wmiService.Name -eq $service.ServiceName) {
                 $ServiceUser     = $wmiService.StartName;
                 $ServiceExitCode = $wmiService.ExitCode;
+                if ([string]::IsNullOrEmpty($wmiService.StartMode) -eq $FALSE) {
+                    $StartModeId = ([int]$ProviderEnums.ServiceWmiStartupType[$wmiService.StartMode]);
+                    $StartMode   = $ProviderEnums.ServiceStartupTypeName[$StartModeId];
+                }
                 break;
             }
         }
@@ -57,34 +63,34 @@ function Get-IcingaServices()
 
         $ServiceData.Add(
             $service.Name, @{
-                'metadata' = @{
-                    'DisplayName' = $service.DisplayName;
-                    'ServiceName' = $service.ServiceName;
-                    'Site' = $service.Site;
-                    'Container' = $service.Container;
+                'metadata'      = @{
+                    'DisplayName'   = $service.DisplayName;
+                    'ServiceName'   = $service.ServiceName;
+                    'Site'          = $service.Site;
+                    'Container'     = $service.Container;
                     'ServiceHandle' = $service.ServiceHandle;
-                    'Dependent' = $DependentServices;
-                    'Depends' = $DependingServices;
+                    'Dependent'     = $DependentServices;
+                    'Depends'       = $DependingServices;
                 };
                 'configuration' = @{
                     'CanPauseAndContinue' = $service.CanPauseAndContinue;
-                    'CanShutdown' = $service.CanShutdown;
-                    'CanStop' = $service.CanStop;
-                    'Status' = @{
-                        'raw' = [int]$service.Status;
+                    'CanShutdown'         = $service.CanShutdown;
+                    'CanStop'             = $service.CanStop;
+                    'Status'              = @{
+                        'raw'   = [int]$service.Status;
                         'value' = $service.Status;
                     };
-                    'ServiceType' = @{
-                        'raw' = [int]$service.ServiceType;
+                    'ServiceType'         = @{
+                        'raw'   = [int]$service.ServiceType;
                         'value' = $service.ServiceType;
                     };
-                    'ServiceHandle' = $service.ServiceHandle;
-                    'StartType' = @{
-                        'raw' = [int]$service.StartType;
-                        'value' = $service.StartType;
+                    'ServiceHandle'       = $service.ServiceHandle;
+                    'StartType'           = @{
+                        'raw'   = $StartModeId;
+                        'value' = $StartMode;
                     };
-                    'ServiceUser' = $ServiceUser;
-                    'ExitCode'    = $ServiceExitCode;
+                    'ServiceUser'         = $ServiceUser;
+                    'ExitCode'            = $ServiceExitCode;
                 }
             }
         );


### PR DESCRIPTION
In some cases, it can happen that `Get-Service` which is used primarily to fetch most of the service data, is not providing any results of the startup type of the service. This results in an error on the plugin, as the monitoring of all services which should be running `Automatic` and throw a critical if not exited properly is no longer possible. The result is simply "Ok" with no services checked as the status code is always 0 for all services and not matching the actual comparison value of 2 (Automatic)