### PR TITLE
Feature: Adds last boot time to uptime check as notice

### DIFF
--- a/doc/31-Changelog.md
+++ b/doc/31-Changelog.md
@@ -20,6 +20,7 @@ If you are going to install this plugin release, please have a look on the [upgr
 * [#134](https://github.com/Icinga/icinga-powershell-plugins/pull/134) Adds autoloading for plugin information to standardize the development and projects and fixes plenty of spelling/code styling errors
 * [#135](https://github.com/Icinga/icinga-powershell-plugins/pull/135) Adds new check plugin `Invoke-IcingaCheckTCP`
 * [#137](https://github.com/Icinga/icinga-powershell-plugins/pull/137) Adds new configuration for Icinga for Windows v1.4.0 to make future configuration changes unnecessary. Please read the [upgrading docs](30-Upgrading-Plugins.md) before upgrading!
+* [#139](https://github.com/Icinga/icinga-powershell-plugins/pull/139) Adds check note for the last boot time for `Invoke-IcingaCheckUptime` which is being displayed by using `-Verbosity 2` on the check configuration
 
 ### Bugfixes
 


### PR DESCRIPTION
Adds check note for the last boot time which is being displayed by using `-Verbosity 2` on the check configuration.

```
[OK] Check package "System Uptime: 8d 1h 28m 50s" (Match All)
\_ [OK] Last Boot: 02/16/2021 08:50:45
\_ [OK] System Uptime: 696530.888485s
```

Fixes #122