### PR TITLE
Fix: Copy & paste error in variable naming on Invoke-IcingaCheckUsedPartitionSpace

### DIFF
--- a/doc/31-Changelog.md
+++ b/doc/31-Changelog.md
@@ -21,6 +21,7 @@ Released closed milestones can be found on [GitHub](https://github.com/Icinga/ic
 * [#147](https://github.com/Icinga/icinga-powershell-plugins/pull/1470) Fixes wrong comparison for file size on `Get-IcingaDirectorySizeSmallerThan`, used by `Invoke-IcingaCheckDirectory`
 * [#154](https://github.com/Icinga/icinga-powershell-plugins/issues/154) Fixes `Invoke-IcingaCheckDirectory` by setting `-FileNames` argument to `*` as default for allowing to fetch all files for a given directory by default
 * [#160](https://github.com/Icinga/icinga-powershell-plugins/issues/160) While filtering for certain services with `Get-IcingaServices`, there were some attributes missing from the collection. These are now added resulting in always correct output data.
+* [#161](https://github.com/Icinga/icinga-powershell-plugins/issues/161) Fixes a copy & paste error on `Invoke-IcingaCheckUsedPartitionSpace`, as a wrong check variable was used for forcing `Unknown` results
 
 ## 1.4.0 (2021-03-02)
 

--- a/plugins/Invoke-IcingaCheckUsedPartitionSpace.psm1
+++ b/plugins/Invoke-IcingaCheckUsedPartitionSpace.psm1
@@ -142,7 +142,7 @@ function Invoke-IcingaCheckUsedPartitionSpace()
             $IcingaCheckByte.WarnOutOfRange($DiskTotalWarning).CritOutOfRange($DiskTotalCritical) | Out-Null;
         } else {
             if ($SkipUnknown -eq $FALSE) {
-                $IcingaCheck.SetUnknown() | Out-Null;
+                $IcingaCheckByte.SetUnknown() | Out-Null;
             }
         }
         $DiskBytePackage.AddCheck($IcingaCheckByte);


### PR DESCRIPTION
Fixes a copy & paste error on `Invoke-IcingaCheckUsedPartitionSpace`, as a wrong check variable was used for forcing `Unknown`.