### PR TITLE
Fix: Improves exception handling for check NLA

### DIFF
--- a/doc/31-Changelog.md
+++ b/doc/31-Changelog.md
@@ -32,6 +32,7 @@ Released closed milestones can be found on [GitHub](https://github.com/Icinga/ic
 * [#160](https://github.com/Icinga/icinga-powershell-plugins/issues/160) While filtering for certain services with `Get-IcingaServices`, there were some attributes missing from the collection. These are now added resulting in always correct output data.
 * [#161](https://github.com/Icinga/icinga-powershell-plugins/issues/161) Fixes a copy & paste error on `Invoke-IcingaCheckUsedPartitionSpace`, as a wrong check variable was used for forcing `Unknown` results
 * [#171](https://github.com/Icinga/icinga-powershell-plugins/issues/171) Fixes wrong OK states for `Invoke-IcingaCheckPerfCounter`, in case counters for categories with instances were not present
+* [#178](https://github.com/Icinga/icinga-powershell-plugins/pull/178) Fixes exception handling for `Invoke-IcingaCheckNLA` to properly handle errors while checking for connection profiles
 
 ## 1.4.0 (2021-03-02)
 

--- a/plugins/Invoke-IcingaCheckNLA.psm1
+++ b/plugins/Invoke-IcingaCheckNLA.psm1
@@ -41,7 +41,7 @@ function Invoke-IcingaCheckNLA()
     $NLAPackage = New-IcingaCheckPackage -Name 'NLA' -OperatorAnd -Verbose $Verbosity;
 
     if ($NICs.Count -eq 0) {
-        foreach ($NLAData in Get-NetConnectionProfile) {
+        foreach ($NLAData in (Get-NetConnectionProfile -ErrorAction Stop)) {
             $NLAName = $NLAData.InterfaceAlias;
             $NLACheck = New-IcingaCheck -Name "NLA for $NLAName" $NLAData.NetworkCategory -ObjectExists $NLAData -NoPerfData;
             $NLACheck.CritIfNotMatch([string]$Profile) | Out-Null;
@@ -49,7 +49,7 @@ function Invoke-IcingaCheckNLA()
         }
     } else {
         foreach ($NIC in $NICs) {
-            $NLAData = (Get-NetConnectionProfile -InterfaceAlias $NIC);
+            $NLAData = (Get-NetConnectionProfile -InterfaceAlias $NIC -ErrorAction Stop);
             $NLACheck = New-IcingaCheck -Name "NLA for $NIC" -Value $NLAData.NetworkCategory -ObjectExists $NLAData -NoPerfData;
             $NLACheck.CritIfNotMatch([string]$Profile) | Out-Null;
             $NLAPackage.AddCheck($NLACheck);


### PR DESCRIPTION
Fixes exception hanlding for `Invoke-IcingaCheckNLA` to properly handle errors while checking for connection profiles