### PR TITLE
Fix: Exception on Invoke-CheckNetworkInterface on duplicate team interface

### DIFF
--- a/doc/31-Changelog.md
+++ b/doc/31-Changelog.md
@@ -36,7 +36,8 @@ Please have a look on the [upgrading docs](30-Upgrading-Plugins) for these plugi
 ### Bugfixes
 
 * [#144](https://github.com/Icinga/icinga-powershell-plugins/pull/144) Fixes filtering for `Invoke-IcingaCheckEventLog` which resulted in wrong results, depending on the plugin configuration
-* [#147](https://github.com/Icinga/icinga-powershell-plugins/pull/1470) Fixes wrong comparison for file size on `Get-IcingaDirectorySizeSmallerThan`, used by `Invoke-IcingaCheckDirectory`
+* [#147](https://github.com/Icinga/icinga-powershell-plugins/pull/147) Fixes wrong comparison for file size on `Get-IcingaDirectorySizeSmallerThan`, used by `Invoke-IcingaCheckDirectory`
+* [#148](https://github.com/Icinga/icinga-powershell-plugins/issues/148) Fixes exception on `Invoke-CheckNetworkInterface` while two team interfaces with the identical name are present on the system
 * [#154](https://github.com/Icinga/icinga-powershell-plugins/issues/154) Fixes `Invoke-IcingaCheckDirectory` by setting `-FileNames` argument to `*` as default for allowing to fetch all files for a given directory by default
 * [#160](https://github.com/Icinga/icinga-powershell-plugins/issues/160) While filtering for certain services with `Get-IcingaServices`, there were some attributes missing from the collection. These are now added resulting in always correct output data.
 * [#161](https://github.com/Icinga/icinga-powershell-plugins/issues/161) Fixes a copy & paste error on `Invoke-IcingaCheckUsedPartitionSpace`, as a wrong check variable was used for forcing `Unknown` results

--- a/provider/network/Get-IcingaNetworkDeviceInfo.psm1
+++ b/provider/network/Get-IcingaNetworkDeviceInfo.psm1
@@ -54,7 +54,7 @@ function Get-IcingaNetworkDeviceInfo()
             'HardwareInterface'                                = $null;
             'HealthState'                                      = $null;
             'Hidden'                                           = $null;
-            'HigherLayerInterfaceIndices'                      = @{};
+            'HigherLayerInterfaceIndices'                      = @{ };
             'IdentifyingDescriptions'                          = $null;
             'IMFilter'                                         = $null;
             'InstallDate'                                      = $network.InstallDate;
@@ -118,25 +118,27 @@ function Get-IcingaNetworkDeviceInfo()
             'Virtual'                                          = $null;
             'VlanID'                                           = $null;
             'WdmInterface'                                     = $networkWdmInterface;
-            'AdminStatus'                                      = @{};
-            'DriverFileName'                                   = @{};
-            'DriverInformation'                                = @{};
-            'ifOperStatus'                                     = @{};
-            'LinkSpeed'                                        = @{};
+            'AdminStatus'                                      = @{ };
+            'DriverFileName'                                   = @{ };
+            'DriverInformation'                                = @{ };
+            'ifOperStatus'                                     = @{ };
+            'LinkSpeed'                                        = @{ };
             'MACAddress'                                       = $network.MAcAddress;
-            'MediaConnectionState'                             = @{};
-            'MediaType'                                        = @{};
-            'NdisVersion'                                      = @{};
-            'PhysicalMediaType'                                = @{};
+            'MediaConnectionState'                             = @{ };
+            'MediaType'                                        = @{ };
+            'NdisVersion'                                      = @{ };
+            'PhysicalMediaType'                                = @{ };
             'Status'                                           = $network.Status;
             'ConfigManagerUserConfig'                          = $null;
         }
 
-        # Add MSFT Netowrk Device information to which we get from the WMI class
+        # Add MSFT Network Device information to which we get from the WMI class
         foreach ($msft_device in $MSFT_Devices) {
             if ((($GetTeamInfo.ContainsKey($msft_device.Name)) -eq $TRUE) -And $msft_device.Name -ne $TeamName) {
                 $TeamName = $msft_device.Name;
-                $TeamDetails.Add($msft_device.Name, $GetTeamInfo[$msft_device.Name]);
+                if ($TeamDetails.ContainsKey($msft_device.Name) -eq $FALSE) {
+                    $TeamDetails.Add($msft_device.Name, $GetTeamInfo[$msft_device.Name]);
+                }
             }
 
             if ($network.GUID -Contains $msft_device.InstanceID) {


### PR DESCRIPTION
Fixes exception on `Invoke-CheckNetworkInterface` while two team interfaces with the identical name are present on the system

Fixes #148