### PR TITLE
Fix: Time offset calculation for Invoke-IcingaCheckTimeSync should allow negative offset

### DIFF
--- a/doc/31-Changelog.md
+++ b/doc/31-Changelog.md
@@ -42,6 +42,7 @@ Please have a look on the [upgrading docs](30-Upgrading-Plugins) for these plugi
 * [#160](https://github.com/Icinga/icinga-powershell-plugins/issues/160) While filtering for certain services with `Get-IcingaServices`, there were some attributes missing from the collection. These are now added resulting in always correct output data.
 * [#161](https://github.com/Icinga/icinga-powershell-plugins/issues/161) Fixes a copy & paste error on `Invoke-IcingaCheckUsedPartitionSpace`, as a wrong check variable was used for forcing `Unknown` results
 * [#171](https://github.com/Icinga/icinga-powershell-plugins/issues/171) Fixes wrong OK states for `Invoke-IcingaCheckPerfCounter`, in case counters for categories with instances were not present
+* [#176](https://github.com/Icinga/icinga-powershell-plugins/issues/176) Fixes offset calculation for `Invoke-IcingaCheckTimeSync`, to allow negative offset as well
 * [#178](https://github.com/Icinga/icinga-powershell-plugins/pull/178) Fixes exception handling for `Invoke-IcingaCheckNLA` to properly handle errors while checking for connection profiles
 
 ## 1.4.0 (2021-03-02)

--- a/provider/ntp/Get-IcingaNtpData.psm1
+++ b/provider/ntp/Get-IcingaNtpData.psm1
@@ -118,7 +118,7 @@ function Get-IcingaNtpData()
         'NtpTime'          = $NtpDateTime;
         'TimeOffset'       = [Math]::Round($Offset / 1000, 3);
         'Delay'            = [Math]::Round($Delay / 1000, 3);
-        'CalculatedOffset' = (Get-IcingaValue -Value ([Math]::Round($Offset / 1000, 2) - $TimeOffset) -Compare 0 -Maximum);
+        'CalculatedOffset' = ([Math]::Round($Offset / 1000, 2) - $TimeOffset);
         'ServerVersion'    = $VersionN;
         'LocalTime'        = $LocalDateTime;
         'SyncStatus'       = $SyncStatus;


### PR DESCRIPTION
Fixes offset calculation for `Invoke-IcingaCheckTimeSync`, to allow negative offset as well

Fixes #176