### PR TITLE
Fix: PermissionDenied exception on Invoke-IcingaCheckDirectory

### DIFF
--- a/doc/31-Changelog.md
+++ b/doc/31-Changelog.md
@@ -13,6 +13,7 @@ Released closed milestones can be found on [GitHub](https://github.com/Icinga/ic
 
 ## Bugfixes
 
+[#196](https://github.com/Icinga/icinga-powershell-plugins/issues/196) Fixes unhandled PermissionDenied exceptions for `Invoke-IcingaCheckDirectory`, in case required permissions for files and folders were not set
 [#202](https://github.com/Icinga/icinga-powershell-plugins/pull/202) Fixes `\` and `/` which are now removed again for `-Include` and `-Exclude` arrays on `Invoke-IcingaCheckUsedPartitionSpace`.
 
 ## 1.5.0 (2021-06-02)

--- a/provider/enums/IcingaGeneralPlugins_Exceptions.psm1
+++ b/provider/enums/IcingaGeneralPlugins_Exceptions.psm1
@@ -4,9 +4,14 @@
     EventLogNoMessageEntries = 'Failed to fetch EventLog information. The argument `-MaxEntries` requires to be greater or equal 1';
 };
 
+[hashtable]$FileSystem = @{
+    PermissionDenied = 'You are not permitted to access the defined path.';
+}
+
 if ($null -eq $IcingaPluginExceptions) {
     [hashtable]$IcingaPluginExceptions = @{
-        Inputs = $Inputs;
+        Inputs     = $Inputs;
+        FileSystem = $FileSystem;
     }
 }
 


### PR DESCRIPTION
Fixes unhandled PermissionDenied exceptions for `Invoke-IcingaCheckDirectory`, in case required permissions for files and folders were not set

Fixes #196