### PR TITLE
FIx: Invoke-IcingaCheckUsedPartitionSpace returns UNKNOWN instead of CRITICAL on case partition has no space left

### DIFF
--- a/doc/31-Changelog.md
+++ b/doc/31-Changelog.md
@@ -13,6 +13,7 @@ Released closed milestones can be found on [GitHub](https://github.com/Icinga/ic
 
 ## Bugfixes
 
+* [#200](https://github.com/Icinga/icinga-powershell-plugins/issues/200) Fixes `UNKNOWN` for `Invoke-IcingaCheckUsedPartitionSpace`, in case the main partition has no space left which should return `CRITICAL` instead
 * [#233](https://github.com/Icinga/icinga-powershell-plugins/pull/233) Fixes used partition space plugin performance by fetching only partition space data instead of entire disk information collection and renamed it to represent the new method of being able to toggle between free and used space for partitions
 * [#235](https://github.com/Icinga/icinga-powershell-plugins/pull/235) Fixes operational status monitoring output for `Invoke-IcingaCheckDiskHealth`
 


### PR DESCRIPTION
In case the main partition of Windows has no space left, the Invoke-IcingaCheckUsedPartitionSpace plugin returned falsely UNKNOWN because of internal exceptions being catched.

This fix will now always ensuse that in this case, the plugin witll return CRITICAL with a basic message that no space is left on the partition, as there are no other information available during this state.

Fixes #200