### PR TITLE
Feature: Replaces Get-FileHash with own implementation

### DIFF
--- a/doc/31-Changelog.md
+++ b/doc/31-Changelog.md
@@ -15,6 +15,7 @@ Released closed milestones can be found on [GitHub](https://github.com/Icinga/ic
 
 * [#208](https://github.com/Icinga/icinga-powershell-plugins/issues/208) Adds additional features to `Invoke-IcingaCheckScheduledTask`, allowing to monitor exit codes, missed runs and last/next run time of a task
 * [#217](https://github.com/Icinga/icinga-powershell-plugins/issues/217) Adds feature for `Invoke-IcingaCheckPerfCounter` with new switch `-IgnoreEmptyChecks` to change the output from `UNKNOWN` to `OK`, in case no performance counters were found
+* [#222](https://github.com/Icinga/icinga-powershell-plugins/pull/222) Replaces `Get-FileHash` with own implementation as `Get-IcingaFileHash`, to work with new JEA integration
 
 ## 1.5.1 (2021-07-07)
 

--- a/plugins/Invoke-IcingaCheckCheckSum.psm1
+++ b/plugins/Invoke-IcingaCheckCheckSum.psm1
@@ -63,7 +63,7 @@ function Invoke-IcingaCheckCheckSum()
         Exit-IcingaThrowException -Force -CustomMessage '"-Path" is not directing to a file' -ExceptionType 'Configuration' -ExceptionThrown $IcingaExceptions.Configuration.PluginArgumentConflict;
     }
 
-    [string]$FileHash = (Get-FileHash $Path -Algorithm $Algorithm).Hash
+    [string]$FileHash = (Get-IcingaFileHash $Path -Algorithm $Algorithm).Hash
     $CheckSumCheck    = New-IcingaCheck -Name "CheckSum $Path" -Value $FileHash;
 
     If (([string]::IsNullOrEmpty($Hash)) -eq $FALSE) {


### PR DESCRIPTION
We have to replace `Get-FileHash` which is a native PowerShell implementation for `Get-IcingaFileHash` as custom implementation, to ensure plugins using this function are working properly in JEA context.