### PR TITLE
Fix: UsedPartitionSpace plugin had wrong label name for partitions

### DIFF
--- a/doc/31-Changelog.md
+++ b/doc/31-Changelog.md
@@ -11,6 +11,10 @@ Released closed milestones can be found on [GitHub](https://github.com/Icinga/ic
 
 [Issue and PRs](https://github.com/Icinga/icinga-powershell-plugins/milestone/8?closed=1)
 
+## Bugfixes
+
+* [#224](https://github.com/Icinga/icinga-powershell-plugins/pull/224) Fixes `Invoke-IcingaCheckUsedPartitionSpace` label names, which might have caused conflicts with Graphite/InfluxDB, because of changed metric unit
+
 ### Enhancements
 
 * [#208](https://github.com/Icinga/icinga-powershell-plugins/issues/208) Adds additional features to `Invoke-IcingaCheckScheduledTask`, allowing to monitor exit codes, missed runs and last/next run time of a task

--- a/plugins/Invoke-IcingaCheckUsedPartitionSpace.psm1
+++ b/plugins/Invoke-IcingaCheckUsedPartitionSpace.psm1
@@ -112,15 +112,17 @@ function Invoke-IcingaCheckUsedPartitionSpace()
                 continue;
             }
 
+            $FormattedLetter = $partition.DriveLetter.Replace(':', '').ToLower();
+
             foreach ($entry in $Include) {
                 $ProcessPartition = $FALSE;
-                if ($entry.Replace(':', '').Replace('\', '').Replace('/', '').ToLower() -eq $partition.DriveLetter.Replace(':', '').ToLower()) {
+                if ($entry.Replace(':', '').Replace('\', '').Replace('/', '').ToLower() -eq $FormattedLetter) {
                     $ProcessPartition = $TRUE;
                     break;
                 }
             }
             foreach ($entry in $Exclude) {
-                if ($entry.Replace(':', '').Replace('\', '').Replace('/', '').ToLower() -eq $partition.DriveLetter.Replace(':', '').ToLower()) {
+                if ($entry.Replace(':', '').Replace('\', '').Replace('/', '').ToLower() -eq $FormattedLetter) {
                     $ProcessPartition = $FALSE;
                     break;
                 }
@@ -130,7 +132,7 @@ function Invoke-IcingaCheckUsedPartitionSpace()
                 continue;
             }
 
-            $IcingaCheck = New-IcingaCheck -Name ([string]::Format('Partition {0}', $partition.DriveLetter)) -Value $partition.UsedSpace -Unit 'B' -Minimum 0 -Maximum $partition.Size -NoPerfData:$SetUnknown -BaseValue $partition.Size;
+            $IcingaCheck = New-IcingaCheck -Name ([string]::Format('Partition {0}', $partition.DriveLetter)) -Value $partition.UsedSpace -Unit 'B' -Minimum 0 -Maximum $partition.Size -LabelName ([string]::Format('used_space_partition_{0}', $FormattedLetter)) -NoPerfData:$SetUnknown -BaseValue $partition.Size;
 
             if ([string]::IsNullOrEmpty($partition.FreeSpace) -Or [string]::IsNullOrEmpty($partition.Size)) {
                 if ($SkipUnknown -eq $FALSE) {


### PR DESCRIPTION
Fixes label name for `Invoke-IcingaCheckUsedPartitionSpace`, by renaming them from `partition_{0}` back to `used_space_partition_{0}`, as otherwise we run into metric displaying issues with Graphite/InfluxDB.