### PR TITLE
Fix: Operational status output for disk health plugin

### DIFF
--- a/doc/31-Changelog.md
+++ b/doc/31-Changelog.md
@@ -7,6 +7,14 @@ documentation before upgrading to a new release.
 
 Released closed milestones can be found on [GitHub](https://github.com/Icinga/icinga-powershell-plugins/milestones?state=closed).
 
+## 1.7.0 (2021-11-09)
+
+[Issue and PRs](https://github.com/Icinga/icinga-powershell-plugins/milestone/10?closed=1)
+
+## Bugfixes
+
+* [#235](https://github.com/Icinga/icinga-powershell-plugins/pull/235) Fixes operational status monitoring output for `Invoke-IcingaCheckDiskHealth`
+
 ## 1.6.0 (2021-09-07)
 
 [Issue and PRs](https://github.com/Icinga/icinga-powershell-plugins/milestone/8?closed=1)

--- a/provider/disks/Get-IcingaPhysicalDiskInfo.psm1
+++ b/provider/disks/Get-IcingaPhysicalDiskInfo.psm1
@@ -126,12 +126,26 @@ function Get-IcingaPhysicalDiskInfo()
                 $DiskInfo.HealthStatus      = $msft_disk.HealthStatus;
                 if ($null -ne $msft_disk.OperationalStatus) {
                     $OperationalStatus = @{ };
+
                     foreach ($entry in $msft_disk.OperationalStatus) {
-                        Add-IcingaHashtableItem -Hashtable $OperationalStatus -Key ([int]$entry) -Value ($ProviderEnums.DiskOperationalStatus[[int]$entry]) | Out-Null;
+                        if (Test-Numeric $entry) {
+                            Add-IcingaHashtableItem -Hashtable $OperationalStatus -Key ([int]$entry) -Value ($ProviderEnums.DiskOperationalStatus[[int]$entry]) | Out-Null;
+                        } else {
+                            if ($ProviderEnums.DiskOperationalStatus.Values -Contains $entry) {
+                                foreach ($opStatus in $ProviderEnums.DiskOperationalStatus.Keys) {
+                                    $opStatusValue = $ProviderEnums.DiskOperationalStatus[$opStatus];
+                                    if ($opStatusValue.ToLower() -eq ([string]$entry).ToLower()) {
+                                        Add-IcingaHashtableItem -Hashtable $OperationalStatus -Key ([int]$opStatus) -Value $entry | Out-Null;
+                                        break;
+                                    }
+                                }
+                            }
+                        }
                     }
+
                     $DiskInfo.OperationalStatus = $OperationalStatus;
                 } else {
-                    $DiskInfo.OperationalStatus  = @{ 0 = 'Unknown'; };
+                    $DiskInfo.OperationalStatus = @{ 0 = 'Unknown'; };
                 }
                 $DiskInfo.Add(
                     'SpindleSpeed', $msft_disk.SpindleSpeed


### PR DESCRIPTION
Fixes invalid output for disk health plugin, as operational status was most of the time printed as hashtable item instead of the actual item.