### PR TITLE
Feature: Adds metadata to disk on disk health plugin if available

### DIFF
--- a/doc/31-Changelog.md
+++ b/doc/31-Changelog.md
@@ -15,6 +15,10 @@ Released closed milestones can be found on [GitHub](https://github.com/Icinga/ic
 
 * [#235](https://github.com/Icinga/icinga-powershell-plugins/pull/235) Fixes operational status monitoring output for `Invoke-IcingaCheckDiskHealth`
 
+### Enhancements
+
+* [#199](https://github.com/Icinga/icinga-powershell-plugins/issues/199) Adds additional metadata to `Invoke-IcingaCheckDiskHealth` for disk serial number, assigned partitions, boot device, device id, system device and device name
+
 ## 1.6.0 (2021-09-07)
 
 [Issue and PRs](https://github.com/Icinga/icinga-powershell-plugins/milestone/8?closed=1)

--- a/plugins/Invoke-IcingaCheckDiskHealth.psm1
+++ b/plugins/Invoke-IcingaCheckDiskHealth.psm1
@@ -252,6 +252,55 @@ function Invoke-IcingaCheckDiskHealth()
             # Check for Disk OperationalStatus
             $PartCheckPackage.AddCheck($DiskOfflineCheck);
             $PartCheckPackage.AddCheck($DiskReadOnlyCheck);
+
+            $PartCheckPackage.AddCheck(
+                (
+                    New-IcingaCheck `
+                        -Name ([string]::Format('{0} Serial Number', $Partition)) `
+                        -Value ([string]$DiskObjects.Data.SerialNumber) `
+                        -NoPerfData
+                ).SetOk([string]$DiskObjects.Data.SerialNumber, $TRUE)
+            );
+            $PartCheckPackage.AddCheck(
+                (
+                    New-IcingaCheck `
+                        -Name ([string]::Format('{0} Is System', $Partition)) `
+                        -Value ([bool]$DiskObjects.Data.IsSystem) `
+                        -NoPerfData
+                )
+            );
+            $PartCheckPackage.AddCheck(
+                (
+                    New-IcingaCheck `
+                        -Name ([string]::Format('{0} Is Boot', $Partition)) `
+                        -Value $DiskObjects.Data.IsBoot `
+                        -NoPerfData
+                )
+            );
+            $PartCheckPackage.AddCheck(
+                (
+                    New-IcingaCheck `
+                        -Name ([string]::Format('{0} Device ID', $Partition)) `
+                        -Value $DiskObjects.Data.DeviceID `
+                        -NoPerfData
+                )
+            );
+            $PartCheckPackage.AddCheck(
+                (
+                    New-IcingaCheck `
+                        -Name ([string]::Format('{0} Caption', $Partition)) `
+                        -Value ([string]$DiskObjects.Data.Caption) `
+                        -NoPerfData
+                ).SetOk([string]$DiskObjects.Data.Caption, $TRUE)
+            );
+            $PartCheckPackage.AddCheck(
+                (
+                    New-IcingaCheck `
+                        -Name ([string]::Format('{0} Assigned Partitions', $Partition)) `
+                        -Value ($DiskObjects.Data.DriveReference.Keys | Out-String).Replace("`r`n", ' ').Replace("`n", ' ') `
+                        -NoPerfData
+                )
+            );
         } else {
             if ($CheckLogicalOnly) {
                 continue;


### PR DESCRIPTION
Adds additional metadata to `Invoke-IcingaCheckDiskHealth` for disk serial number, assigned partitions, boot device, device id, system device and device name

Fixes #199