### PR TITLE
Fix: Wrong UNKNOWN while using service display name

### DIFF
--- a/doc/31-Changelog.md
+++ b/doc/31-Changelog.md
@@ -7,6 +7,12 @@ documentation before upgrading to a new release.
 
 Released closed milestones can be found on [GitHub](https://github.com/Icinga/icinga-powershell-plugins/milestones?state=closed).
 
+## 1.8.0 (2022-02-08)
+
+[Issue and PRs](https://github.com/Icinga/icinga-powershell-plugins/milestone/11?closed=1)
+
+* [#246](https://github.com/Icinga/icinga-powershell-plugins/pull/246) Fixes wrong `UNKNOWN` on `Invoke-IcingaCheckService` while using service display name with the `-Service` argument instead of the service name
+
 ## 1.7.0 (2021-11-09)
 
 [Issue and PRs](https://github.com/Icinga/icinga-powershell-plugins/milestone/10?closed=1)

--- a/plugins/Invoke-IcingaCheckService.psm1
+++ b/plugins/Invoke-IcingaCheckService.psm1
@@ -144,6 +144,24 @@ function Invoke-IcingaCheckService()
             if ($ServiceArg.Contains('*')) {
                 continue;
             }
+
+            # As we can use the DisplayName of a service inside the filter, we need to compare the DisplayName with
+            # our provided filter as well
+            [bool]$ServiceKnown = $FALSE;
+
+            foreach ($fetchedService in $FetchedServices.Keys) {
+                $fetchedService = $FetchedServices[$fetchedService];
+
+                if ($fetchedService.metadata.DisplayName -eq $ServiceArg) {
+                    $ServiceKnown = $TRUE;
+                    break;
+                }
+            }
+
+            if ($ServiceKnown) {
+                continue;
+            }
+
             $ServicesPackage.AddCheck(
                 (New-IcingaCheck -Name ([string]::Format('{0}: Service not found', $ServiceArg))).SetUnknown()
             );


### PR DESCRIPTION
While using the service display name for `Invoke-IcingaCheckService`, the correct service is added, but also an unknown because we only checked if the service is present by it's name instead of the display name.

This will now resolve this issue and allow the monitoring by using the name and the display name with proper results.