### PR TITLE
Fix: Partition Space Plugin alias not Working on 2012R2

### DIFF
--- a/doc/31-Changelog.md
+++ b/doc/31-Changelog.md
@@ -23,6 +23,7 @@ Released closed milestones can be found on [GitHub](https://github.com/Icinga/ic
 * [#200](https://github.com/Icinga/icinga-powershell-plugins/issues/200) Fixes `UNKNOWN` for `Invoke-IcingaCheckUsedPartitionSpace`, in case the main partition has no space left which should return `CRITICAL` instead
 * [#233](https://github.com/Icinga/icinga-powershell-plugins/pull/233) Fixes used partition space plugin performance by fetching only partition space data instead of entire disk information collection and renamed it to represent the new method of being able to toggle between free and used space for partitions
 * [#235](https://github.com/Icinga/icinga-powershell-plugins/pull/235) Fixes operational status monitoring output for `Invoke-IcingaCheckDiskHealth`
+* [#250](https://github.com/Icinga/icinga-powershell-plugins/pull/250) Fixes alias `Invoke-IcingaCheckUsedPartitionSpace` which is not working on Windows 2012R2 or older and being replaced with a native function
 
 ### Enhancements
 

--- a/plugins/Invoke-IcingaCheckUsedPartitionSpace.psm1
+++ b/plugins/Invoke-IcingaCheckUsedPartitionSpace.psm1
@@ -79,7 +79,7 @@
 
 function Invoke-IcingaCheckPartitionSpace()
 {
-    param(
+    param (
         $Warning                   = $null,
         $Critical                  = $null,
         [array]$Include            = @(),
@@ -154,4 +154,31 @@ function Invoke-IcingaCheckPartitionSpace()
 }
 
 # Ensure we do not break current monitoring environments by the renaming change
-Set-Alias -Name 'Invoke-IcingaCheckUsedPartitionSpace' -Value 'Invoke-IcingaCheckPartitionSpace';
+function Invoke-IcingaCheckUsedPartitionSpace()
+{
+    param (
+        $Warning                   = $null,
+        $Critical                  = $null,
+        [array]$Include            = @(),
+        [array]$Exclude            = @(),
+        [switch]$IgnoreEmptyChecks = $FALSE,
+        [switch]$NoPerfData        = $FALSE,
+        [switch]$SkipUnknown       = $FALSE,
+        [switch]$CheckUsedSpace    = $FALSE,
+        [ValidateSet(0, 1, 2, 3)]
+        [int]$Verbosity            = 0
+    );
+
+    return (
+        Invoke-IcingaCheckPartitionSpace `
+            -Warning $Warning `
+            -Critical $Critical `
+            -Include $Include `
+            -Exclude $Exclude `
+            -IgnoreEmptyChecks:$IgnoreEmptyChecks `
+            -NoPerfData:$NoPerfData `
+            -SkipUnknown:$SkipUnknown `
+            -CheckUsedSpace:$CheckUsedSpace `
+            -Verbosity $Verbosity
+    );
+}


### PR DESCRIPTION
The alias for `Invoke-IcingaCheckUsedPartitionSpace` is not working on Windows 2012R2 and older. Therefor we replace it with a native function, calling our new plugin name,

Fixes #250