### PR TITLE
Fix: Method NULL exception on empty EventLog

### DIFF
--- a/doc/31-Changelog.md
+++ b/doc/31-Changelog.md
@@ -11,7 +11,10 @@ Released closed milestones can be found on [GitHub](https://github.com/Icinga/ic
 
 [Issue and PRs](https://github.com/Icinga/icinga-powershell-plugins/milestone/11?closed=1)
 
+## Bugfixes
+
 * [#246](https://github.com/Icinga/icinga-powershell-plugins/pull/246) Fixes wrong `UNKNOWN` on `Invoke-IcingaCheckService` while using service display name with the `-Service` argument instead of the service name
+* [#262](https://github.com/Icinga/icinga-powershell-plugins/pull/262) Fixes method NULL exception on empty EventLog entries for `Invoke-IcingaCheckEventLog`
 
 ## 1.7.0 (2021-11-09)
 

--- a/provider/eventlog/Get-IcingaEventLog.psm1
+++ b/provider/eventlog/Get-IcingaEventLog.psm1
@@ -253,13 +253,17 @@ function Get-IcingaEventLog()
         [string]$EventHash = Get-StringSha1 $EventIdentifier;
 
         if ($groupedEvents.eventlog.ContainsKey($EventHash) -eq $FALSE) {
+            [string]$EventMessage = $event.Message;
+            if ([string]::IsNullOrEmpty($EventMessage)) {
+                $EventMessage = '';
+            }
             $groupedEvents.eventlog.Add(
                 $EventHash,
                 @{
                     NewestEntry = $event.TimeCreated;
                     OldestEntry = $event.TimeCreated;
                     EventId     = $event.Id;
-                    Message     = $event.Message;
+                    Message     = $EventMessage;
                     Severity    = $ProviderEnums.EventLogSeverityName[$event.Level];
                     Source      = $event.ProviderName;
                     Count       = 1;


### PR DESCRIPTION
Fixes method NULL exception on empty EventLog entries, as the `Message` is directly processed within check handler, not ensuring that the string actually contains a valid string and not `$null`.