### PR TITLE
Fix: File encoding to UTF8 for TimeSync plugin

### DIFF
--- a/doc/31-Changelog.md
+++ b/doc/31-Changelog.md
@@ -18,6 +18,7 @@ Released closed milestones can be found on [GitHub](https://github.com/Icinga/ic
 * [#261](https://github.com/Icinga/icinga-powershell-plugins/issues/261) Fixes `Invoke-IcingaCheckCertificate` which always included the CertStore because no option to not check the certificate store was available
 * [#262](https://github.com/Icinga/icinga-powershell-plugins/pull/262) Fixes method NULL exception on empty EventLog entries for `Invoke-IcingaCheckEventLog`
 * [#271](https://github.com/Icinga/icinga-powershell-plugins/pull/271) Fixes JEA error which detected `ScriptBlocks` in the plugin collection
+* [#272](https://github.com/Icinga/icinga-powershell-plugins/pull/272) Fixes file encoding for `Invoke-IcingaCheckTimeSync` which was not UTF8 before, causing the JEA profile writer to ignore the file
 
 ## Enhancements
 

--- a/plugins/Invoke-IcingaCheckTimeSync.psm1
+++ b/plugins/Invoke-IcingaCheckTimeSync.psm1
@@ -1,4 +1,4 @@
-﻿<#
+<#
 .SYNOPSIS
     Gets Network Time Protocol time(SMTP/NTP) from a specified server
 .DESCRIPTION


### PR DESCRIPTION
The plugin `Invoke-IcingaCheckTimeSync` was previously not saved as `UTF8`, causing it to not being loaded properly by the JEA manager of Icinga for Windows.