### PR TITLE
Fix: Wrong process count number for process check

### DIFF
--- a/plugins/Invoke-IcingaCheckProcess.psm1
+++ b/plugins/Invoke-IcingaCheckProcess.psm1
@@ -203,7 +203,7 @@ function Invoke-IcingaCheckProcess()
         $ThreadCheck.WarnOutOfRange($TotalThreadCountWarning).CritOutOfRange($TotalThreadCountCritical) | Out-Null;
         $ProcessSummary.AddCheck($ThreadCheck);
 
-        $ProcessCheck = New-IcingaCheck -Name 'Process Count' -Value $ProcessData.PerformanceData.ThreadCount -Unit 'c' -LabelName (Format-IcingaPerfDataLabel ([string]::Format('{0}_process_count', $processName.ToLower())));
+        $ProcessCheck = New-IcingaCheck -Name 'Process Count' -Value $ProcessData.ProcessList.Count -Unit 'c' -LabelName (Format-IcingaPerfDataLabel ([string]::Format('{0}_process_count', $processName.ToLower())));
         $ProcessCheck.WarnOutOfRange($TotalProcessCountWarning).CritOutOfRange($TotalProcessCountCritical) | Out-Null;
         $ProcessSummary.AddCheck($ProcessCheck);
 


### PR DESCRIPTION
Fixes the wrong process count for `Invoke-IcingaCheckProcess`, which was the thread count before.