### PR TITLE
Fix: Add-Type exceptions during runtime compilation

### DIFF
--- a/doc/31-Changelog.md
+++ b/doc/31-Changelog.md
@@ -7,6 +7,14 @@ documentation before upgrading to a new release.
 
 Released closed milestones can be found on [GitHub](https://github.com/Icinga/icinga-powershell-plugins/milestones?state=closed).
 
+## 1.9.0 (2022-05-03)
+
+[Issue and PRs](https://github.com/Icinga/icinga-powershell-plugins/milestone/12?closed=1)
+
+### Bugfixes
+
+* [#283](https://github.com/Icinga/icinga-powershell-plugins/pull/283) Fixes random `Add-Type` exceptions during runtime compilation by replacing it with `Add-IcingaAddTypeLib`
+
 ## 1.8.0 (2022-02-08)
 
 [Issue and PRs](https://github.com/Icinga/icinga-powershell-plugins/milestone/11?closed=1)

--- a/icinga-powershell-plugins.psd1
+++ b/icinga-powershell-plugins.psd1
@@ -7,7 +7,7 @@
     Copyright         = '(c) 2021 Icinga GmbH | GPLv2'
     Description       = 'A collection of Icinga Plugins for general Windows checks for Icinga for Windows.'
     PowerShellVersion = '4.0'
-    RequiredModules   = @(@{ModuleName = 'icinga-powershell-framework'; ModuleVersion = '1.7.0' })
+    RequiredModules   = @(@{ModuleName = 'icinga-powershell-framework'; ModuleVersion = '1.9.0' })
     NestedModules     = @(
         '.\plugins\Invoke-IcingaCheckBiosSerial.psm1',
         '.\plugins\Invoke-IcingaCheckCertificate.psm1',

--- a/provider/disks/Get-IcingaDiskAttributes.psm1
+++ b/provider/disks/Get-IcingaDiskAttributes.psm1
@@ -74,17 +74,15 @@ function Get-IcingaDiskAttributes()
             }
 "@
 
-    if ((Test-IcingaAddTypeExist 'IcingaDiskAttributes') -eq $FALSE) {
-        try {
-            Add-Type -TypeDefinition $IcingaDiskAttributesClass;
-        } catch {
-            [string]$ExErrorId = $_.FullyQualifiedErrorId;
+    try {
+        Add-IcingaAddTypeLib -TypeName 'IcingaDiskAttributes' -TypeDefinition $IcingaDiskAttributesClass;
+    } catch {
+        [string]$ExErrorId = $_.FullyQualifiedErrorId;
 
-            Exit-IcingaThrowCritical `
-                -Message 'Failed to process disk related checks. Based on the error your local Windows disk partition has no space left' `
-                -FilterString $ExErrorId `
-                -SearchString 'System.IO.IOException';
-        }
+        Exit-IcingaThrowCritical `
+            -Message 'Failed to process disk related checks. Based on the error your local Windows disk partition has no space left' `
+            -FilterString $ExErrorId `
+            -SearchString 'System.IO.IOException';
     }
 
     [bool]$DiskOffline  = $FALSE;

--- a/provider/disks/Get-IcingaUNCPathSize.psm1
+++ b/provider/disks/Get-IcingaUNCPathSize.psm1
@@ -12,24 +12,22 @@ function Get-IcingaUNCPathSize()
             -Force;
     }
 
-    if ((Test-IcingaAddTypeExist -Type 'IcingaUNCPath') -eq $FALSE) {
-        # Register our kernel32.dll Windows API function call
-        Add-Type -TypeDefinition @"
-            using System;
-            using System.Runtime.InteropServices;
+    # Register our kernel32.dll Windows API function call
+    Add-IcingaAddTypeLib -TypeName 'IcingaUNCPath' -TypeDefinition @"
+        using System;
+        using System.Runtime.InteropServices;
 
-            public static class IcingaUNCPath {
-                [DllImport("kernel32.dll", PreserveSig = true, CharSet = CharSet.Auto)]
+        public static class IcingaUNCPath {
+            [DllImport("kernel32.dll", PreserveSig = true, CharSet = CharSet.Auto)]
 
-                public static extern int GetDiskFreeSpaceEx(
-                    IntPtr lpDirectoryName,           // UNC Path for share
-                    out long lpFreeBytesAvailable,    // Free Bytes available on path
-                    out long lpTotalNumberOfBytes,    // Bytes available on target disk / path
-                    out long lpTotalNumberOfFreeBytes // Total available space on target disk / path
-                );
-            }
+            public static extern int GetDiskFreeSpaceEx(
+                IntPtr lpDirectoryName,           // UNC Path for share
+                out long lpFreeBytesAvailable,    // Free Bytes available on path
+                out long lpTotalNumberOfBytes,    // Bytes available on target disk / path
+                out long lpTotalNumberOfFreeBytes // Total available space on target disk / path
+            );
+        }
 "@
-    }
 
     # Setup variables as object which we can use to reference data into
     $ShareFree = New-Object -TypeName long;
@@ -39,7 +37,7 @@ function Get-IcingaUNCPathSize()
     # Create a pointer object to our share
     [System.IntPtr]$ptrPath = [System.Runtime.InteropServices.Marshal]::StringToHGlobalAuto($Path);
 
-    # Call our function we registered within the Add-Type definition
+    # Call our function we registered within the Add-IcingaAddTypeLib definition
     [IcingaUNCPath]::GetDiskFreeSpaceEx($ptrPath, [ref]$ShareFree, [ref]$ShareSize, [ref]$TotalFree) | Out-Null;
     $ShareFreePercent = 0;
 


### PR DESCRIPTION
Icinga for Windows is using Add-Type in some small cases, to properly fetch UNC Path values for plugins or disk attribute information.

While in most cases this works without problems, sometimes the on-the-fly compilation fails because of out-of-memory exceptions or different errors.

This fix will now compile the DLL required inside the cache/dll folder if not present and load the compiled DLL's if required and available by using the new Framework function `Add-IcingaAddTypeLib`