### PR TITLE
Fix: Invoke-IcingaCheckHTTPStatus RequestTime return value

### DIFF
--- a/doc/31-Changelog.md
+++ b/doc/31-Changelog.md
@@ -14,6 +14,7 @@ Released closed milestones can be found on [GitHub](https://github.com/Icinga/ic
 ### Bugfixes
 
 * [#283](https://github.com/Icinga/icinga-powershell-plugins/pull/283) Fixes random `Add-Type` exceptions during runtime compilation by replacing it with `Add-IcingaAddTypeLib`
+* [#286](https://github.com/Icinga/icinga-powershell-plugins/issues/286) Fixes `Invoke-IcingaCheckHTTPStatus` which is not returning the request time, in case the target website is not providing content
 
 ## 1.8.0 (2022-02-08)
 

--- a/provider/http/Get-IcingaCheckHTTPQuery.psm1
+++ b/provider/http/Get-IcingaCheckHTTPQuery.psm1
@@ -89,10 +89,11 @@ function Get-IcingaCheckHTTPQuery()
             $enc = [system.Text.Encoding]::UTF8;
             $HTTPData.Add('ContentSize', $enc.GetBytes($HTTPInformation.Content).Length);
             $HTTPData.Add('Content', $HTTPInformation.Content);
-            $HTTPData.Add('RequestTime', (Get-IcingaTimer -Name 'HTTPRequest').Elapsed.TotalSeconds);
         } else {
             $HTTPData.Add('ContentSize', 0);
         }
+
+        $HTTPData.Add('RequestTime', (Get-IcingaTimer -Name 'HTTPRequest').Elapsed.TotalSeconds);
 
         # Determine status code match
 


### PR DESCRIPTION
Fixes `Invoke-IcingaCheckHTTPStatus` which is not returning the request time, in case the target website is not providing content

Fixes #286