### PR TITLE
Fix: Non-public function Get-IcingaServiceCheckName

### DIFF
--- a/doc/31-Changelog.md
+++ b/doc/31-Changelog.md
@@ -7,6 +7,14 @@ documentation before upgrading to a new release.
 
 Released closed milestones can be found on [GitHub](https://github.com/Icinga/icinga-powershell-plugins/milestones?state=closed).
 
+## 1.10.0 (2022-08-09)
+
+[Issue and PRs](https://github.com/Icinga/icinga-powershell-plugins/milestone/13?closed=1)
+
+### Bugfixes
+
+* [#308](https://github.com/Icinga/icinga-powershell-plugins/pull/308) Fixes function `Get-IcingaServiceCheckName` which was not public anymore since v1.9.0, causing MSSQL plugins to not work properly
+
 ## 1.9.0 (2022-05-03)
 
 [Issue and PRs](https://github.com/Icinga/icinga-powershell-plugins/milestone/12?closed=1)

--- a/icinga-powershell-plugins.psd1
+++ b/icinga-powershell-plugins.psd1
@@ -49,6 +49,7 @@
         'Get-IcingaMemoryPerformanceCounter',
         'Get-IcingaMemory',
         'Get-IcingaProcessData',
+        'Get-IcingaServiceCheckName',
         'Get-IcingaUpdatesHotfix',
         'Get-IcingaUpdatesInstalled',
         'Get-IcingaWindowsUpdatesPending',

--- a/provider/private/services/Get-IcingaServiceCheckName.psm1
+++ b/provider/private/services/Get-IcingaServiceCheckName.psm1
@@ -1,4 +1,4 @@
-function Get-IcingaServiceCheckName()
+function Global:Get-IcingaServiceCheckName()
 {
     param (
         [string]$ServiceInput,


### PR DESCRIPTION
Fixes function `Get-IcingaServiceCheckName` which was not public anymore since v1.9.0, causing MSSQL plugins to not work properly