### PR TITLE
Fix: Removes performance metric for CheckSum plugin

### DIFF
--- a/doc/31-Changelog.md
+++ b/doc/31-Changelog.md
@@ -15,6 +15,7 @@ Released closed milestones can be found on [GitHub](https://github.com/Icinga/ic
 
 * [#199](https://github.com/Icinga/icinga-powershell-plugins/issues/199) Fixes `Invoke-IcingaCheckDiskHealth` to add disk metadata like serial number and friendly name for any disk type processed
 * [#308](https://github.com/Icinga/icinga-powershell-plugins/pull/308) Fixes function `Get-IcingaServiceCheckName` which was not public anymore since v1.9.0, causing MSSQL plugins to not work properly
+* [#319](https://github.com/Icinga/icinga-powershell-plugins/pull/319) Removes performance data for `Invoke-IcingaCheckCheckSum`, as there are no real performance metrics to write which are allowed by icinga
 
 ## Enhancements
 

--- a/plugins/Invoke-IcingaCheckCheckSum.psm1
+++ b/plugins/Invoke-IcingaCheckCheckSum.psm1
@@ -64,7 +64,7 @@ function Invoke-IcingaCheckCheckSum()
     }
 
     [string]$FileHash = (Get-IcingaFileHash $Path -Algorithm $Algorithm).Hash
-    $CheckSumCheck    = New-IcingaCheck -Name "CheckSum $Path" -Value $FileHash;
+    $CheckSumCheck    = New-IcingaCheck -Name "CheckSum $Path" -Value $FileHash -NoPerfData;
 
     If (([string]::IsNullOrEmpty($Hash)) -eq $FALSE) {
         $CheckSumCheck.CritIfNotMatch($Hash) | Out-Null;


### PR DESCRIPTION
Removes performance data for `Invoke-IcingaCheckCheckSum`, as there are no real performance metrics to write which are allowed by icinga.