### PR TITLE
Fix: Invalid perf data for service plugin

### DIFF
--- a/doc/31-Changelog.md
+++ b/doc/31-Changelog.md
@@ -9,6 +9,10 @@ Released closed milestones can be found on [GitHub](https://github.com/Icinga/ic
 
 ## 1.10.1 (2022-12-20)
 
+### Bugfixes
+
+* [#323](https://github.com/Icinga/icinga-powershell-plugins/issues/323) Fixes `Invoke-IcingaCheckService` to write invalid performance data in case one service is actively checked and returning `UNKNOWN` because it does not exist
+
 ### Enhancements
 
 * [#322](https://github.com/Icinga/icinga-powershell-plugins/issues/322) Adds flag `-IgnoreService` for plugin `Invoke-IcingaCheckTimeSync` to ignore the time service being evaluated during check runtime

--- a/plugins/Invoke-IcingaCheckService.psm1
+++ b/plugins/Invoke-IcingaCheckService.psm1
@@ -138,6 +138,11 @@ function Invoke-IcingaCheckService()
         }
     }
 
+    # Fix invalid performance data in case only one service was checked and the service does not exist
+    if ($null -eq $ServiceSummary) {
+        $ServiceSummary = Add-IcingaServiceSummary;
+    }
+
     # Check our included services and add an unknown state for each service which was not found on the system
     foreach ($ServiceArg in $Service) {
         if ($null -eq $FetchedServices -Or $FetchedServices.ContainsKey($ServiceArg) -eq $FALSE) {
@@ -163,7 +168,7 @@ function Invoke-IcingaCheckService()
             }
 
             $ServicesPackage.AddCheck(
-                (New-IcingaCheck -Name ([string]::Format('{0}: Service not found', $ServiceArg))).SetUnknown()
+                (New-IcingaCheck -Name ([string]::Format('{0}: Service not found', $ServiceArg)) -NoPerfData).SetUnknown()
             );
         }
     }

--- a/provider/private/services/Add-IcingaServiceSummary.psm1
+++ b/provider/private/services/Add-IcingaServiceSummary.psm1
@@ -52,7 +52,7 @@ function Add-IcingaServiceSummary()
         }
     }
 
-    switch($ServiceStatus) {
+    switch ($ServiceStatus) {
         $ProviderEnums.ServiceStatus.Stopped {
             $ServiceData.StoppedCount += 1;
         };


### PR DESCRIPTION
Fixes `Invoke-IcingaCheckService` to write invalid performance data in case one service is actively checked and returning `UNKNOWN` because it does not exist

#322