### PR TITLE
Fix: Disk health error for int to str enum conversion

### DIFF
--- a/doc/31-Changelog.md
+++ b/doc/31-Changelog.md
@@ -7,6 +7,12 @@ documentation before upgrading to a new release.
 
 Released closed milestones can be found on [GitHub](https://github.com/Icinga/icinga-powershell-plugins/milestones?state=closed).
 
+# 1.11.0 (2023-05-31)
+
+### Bugfixes
+
+* [#342](https://github.com/Icinga/icinga-powershell-plugins/issues/342) Fixes an issue for disk health plugin, which can fail in some cases due to an invalid conversion from the MSFT output from int to string
+
 ## 1.10.1 (2022-12-20)
 
 ### Bugfixes

--- a/provider/disks/Get-IcingaPhysicalDiskInfo.psm1
+++ b/provider/disks/Get-IcingaPhysicalDiskInfo.psm1
@@ -220,7 +220,7 @@ function Global:Get-IcingaPhysicalDiskInfo()
             'BusType',
             @{
                 'value' = $disk.BusType;
-                'name'  = $ProviderEnums.DiskBusType[[int]$disk.BusType];
+                'name'  = (Get-IcingaProviderEnumData -Enum $ProviderEnums -Key 'DiskBusType' -Index $disk.BusType);
             }
         )
         $DiskInfo.Add('HealthStatus', $disk.HealthStatus);
@@ -229,11 +229,11 @@ function Global:Get-IcingaPhysicalDiskInfo()
 
             foreach ($entry in $disk.OperationalStatus) {
                 if (Test-Numeric $entry) {
-                    Add-IcingaHashtableItem -Hashtable $OperationalStatus -Key ([int]$entry) -Value ($ProviderEnums.DiskOperationalStatus[[int]$entry]) | Out-Null;
+                    Add-IcingaHashtableItem -Hashtable $OperationalStatus -Key ([int]$entry) -Value (Get-IcingaProviderEnumData -Enum $ProviderEnums -Key 'DiskOperationalStatus' -Index $entry) | Out-Null;
                 } else {
                     if ($ProviderEnums.DiskOperationalStatus.Values -Contains $entry) {
                         foreach ($opStatus in $ProviderEnums.DiskOperationalStatus.Keys) {
-                            $opStatusValue = $ProviderEnums.DiskOperationalStatus[$opStatus];
+                            $opStatusValue = (Get-IcingaProviderEnumData -Enum $ProviderEnums -Key 'DiskOperationalStatus' -Index $opStatus);
                             if ($opStatusValue.ToLower() -eq ([string]$entry).ToLower()) {
                                 Add-IcingaHashtableItem -Hashtable $OperationalStatus -Key ([int]$opStatus) -Value $entry | Out-Null;
                                 break;
@@ -280,8 +280,8 @@ function Global:Get-IcingaPhysicalDiskInfo()
         $DiskInfo.Add(
             'MediaType',
             @{
-                'Value' = $disk.MediaType
-                'Name'  = ($ProviderEnums.DiskMediaType[[int]$disk.MediaType])
+                'Value' = $disk.MediaType;
+                'Name'  = (Get-IcingaProviderEnumData -Enum $ProviderEnums -Key 'DiskMediaType' -Index $disk.MediaType);
             }
         );
 


### PR DESCRIPTION
Fixes an issue for disk health plugin, which can fail in some cases due to an invalid conversion from the MSFT output from int to string.

Fixes #342