### PR TITLE
Fix: Pagefile provider returning values in MB instead of Bytes

### DIFF
--- a/doc/31-Changelog.md
+++ b/doc/31-Changelog.md
@@ -12,6 +12,7 @@ Released closed milestones can be found on [GitHub](https://github.com/Icinga/ic
 ### Bugfixes
 
 * [#342](https://github.com/Icinga/icinga-powershell-plugins/issues/342) Fixes an issue for disk health plugin, which can fail in some cases due to an invalid conversion from the MSFT output from int to string
+* [#346](https://github.com/Icinga/icinga-powershell-plugins/pull/346) Fixes the pagefile provider at `Get-IcingaMemoryPerformanceCounter` which returned the pagefile size in MB instead of Bytes
 
 ## 1.10.1 (2022-12-20)
 

--- a/provider/memory/Get-IcingaMemoryPerformanceCounter.psm1
+++ b/provider/memory/Get-IcingaMemoryPerformanceCounter.psm1
@@ -60,15 +60,15 @@ function Global:Get-IcingaMemoryPerformanceCounter()
             $MemoryData.PageFile.Add(
                 $entry.Name,
                 @{
-                    'InitialSize' = $entry.InitialSize;
+                    'InitialSize' = $entry.InitialSize * 1024 * 1024;
                     'Managed'     = $TRUE;
                     'Name'        = $entry.Name;
-                    'TotalSize'   = $entry.MaximumSize;
+                    'TotalSize'   = $entry.MaximumSize * 1024 * 1024;
                 }
             );
 
-            $MemoryData['PageFile Total Bytes'] += $entry.MaximumSize;
-            $MemoryData['PageFile Used Bytes']  += $entry.InitialSize;
+            $MemoryData['PageFile Total Bytes'] += $entry.MaximumSize * 1024 * 1024;
+            $MemoryData['PageFile Used Bytes']  += $entry.InitialSize * 1024 * 1024;
         }
     }
 
@@ -78,13 +78,13 @@ function Global:Get-IcingaMemoryPerformanceCounter()
     foreach ($entry in $PageFileUsage) {
         if ($MemoryData.PageFile.ContainsKey($entry.Name)) {
             $MemoryData.PageFile[$entry.Name].Add(
-                'Allocated', $entry.AllocatedBaseSize
+                'Allocated', $entry.AllocatedBaseSize * 1024 * 1024
             );
             $MemoryData.PageFile[$entry.Name].Add(
-                'Usage', $entry.CurrentUsage
+                'Usage', $entry.CurrentUsage * 1024 * 1024
             );
             $MemoryData.PageFile[$entry.Name].Add(
-                'PeakUsage', $entry.PeakUsage
+                'PeakUsage', $entry.PeakUsage * 1024 * 1024
             );
             $MemoryData.PageFile[$entry.Name].Add(
                 'TempPageFile', $entry.TempPageFile
@@ -97,18 +97,18 @@ function Global:Get-IcingaMemoryPerformanceCounter()
             @{
                 'InitialSize'  = 0;
                 'MaximumSize'  = 0;
-                'TotalSize'    = $entry.AllocatedBaseSize;
-                'Allocated'    = $entry.AllocatedBaseSize;
-                'Usage'        = $entry.CurrentUsage;
-                'PeakUsage'    = $entry.PeakUsage;
+                'TotalSize'    = $entry.AllocatedBaseSize * 1024 * 1024;
+                'Allocated'    = $entry.AllocatedBaseSize * 1024 * 1024;
+                'Usage'        = $entry.CurrentUsage * 1024 * 1024;
+                'PeakUsage'    = $entry.PeakUsage * 1024 * 1024;
                 'TempPageFile' = $entry.TempPageFile;
                 'Managed'      = $FALSE;
                 'Name'         = $entry.Name;
             }
         );
 
-        $MemoryData['PageFile Total Bytes'] += $entry.AllocatedBaseSize;
-        $MemoryData['PageFile Used Bytes']  += $entry.CurrentUsage;
+        $MemoryData['PageFile Total Bytes'] += $entry.AllocatedBaseSize * 1024 * 1024;
+        $MemoryData['PageFile Used Bytes']  += $entry.CurrentUsage * 1024 * 1024;
     }
 
     foreach ($entry in $PerfCounters['\Paging File(*)\% usage'].Keys) {


### PR DESCRIPTION
Fixes the pagefile provider at `Get-IcingaMemoryPerformanceCounter` which returned the pagefile size in MB instead of Bytes

Fixes https://github.com/Icinga/icinga-powershell-framework/issues/617