### PR TITLE
CheckMemory: Fix incorrect sizes in pagefile check

### DIFF
--- a/plugins/Invoke-IcingaCheckMemory.psm1
+++ b/plugins/Invoke-IcingaCheckMemory.psm1
@@ -129,7 +129,7 @@ function Invoke-IcingaCheckMemory()
                     -BaseValue $PageFile.TotalSize `
                     -Minimum 0 `
                     -Maximum $PageFile.TotalSize `
-                    -Unit 'MB' `
+                    -Unit 'B' `
                     -LabelName ([string]::Format('pagefile_{0}', (Format-IcingaPerfDataLabel $PageFile.Name))) `
                     -MetricIndex (Format-IcingaPerfDataLabel $PageFile.Name) `
                     -MetricName 'used' `


### PR DESCRIPTION
The unit for pagefile attributes was changed from megabytes to bytes in GH-346 but the call to New-IcingaCheck was not updated to reflect this.

Fixes #360.