### PR TITLE
Fix: Pagefile unit for memory plugin

### DIFF
--- a/doc/31-Changelog.md
+++ b/doc/31-Changelog.md
@@ -16,6 +16,7 @@ Released closed milestones can be found on [GitHub](https://github.com/Icinga/ic
 ### Bugfixes
 
 * [#358](https://github.com/Icinga/icinga-powershell-plugins/issues/358) Fixes broken Icinga plain configuration
+* [#360](https://github.com/Icinga/icinga-powershell-plugins/issues/360) Fixes `Invoke-IcingaCheckMemory` which uses the wrong unit for the pagefile plugin, wrong values, exceptions and %-Values not working
 
 # 1.11.0 (2023-08-01)
 

--- a/plugins/Invoke-IcingaCheckMemory.psm1
+++ b/plugins/Invoke-IcingaCheckMemory.psm1
@@ -129,7 +129,7 @@ function Invoke-IcingaCheckMemory()
                     -BaseValue $PageFile.TotalSize `
                     -Minimum 0 `
                     -Maximum $PageFile.TotalSize `
-                    -Unit 'MB' `
+                    -Unit 'B' `
                     -LabelName ([string]::Format('pagefile_{0}', (Format-IcingaPerfDataLabel $PageFile.Name))) `
                     -MetricIndex (Format-IcingaPerfDataLabel $PageFile.Name) `
                     -MetricName 'used' `


### PR DESCRIPTION
Fixes `Invoke-IcingaCheckMemory` which uses the wrong unit for the pagefile plugin, wrong values, exceptions and %-Values not working

Fixes #338
Fixes #359
Fixes #360