### PR TITLE
Fix the exception "Item has already been added"

### DIFF
--- a/provider/disks/Get-IcingaPhysicalDiskInfo.psm1
+++ b/provider/disks/Get-IcingaPhysicalDiskInfo.psm1
@@ -285,7 +285,9 @@ function Global:Get-IcingaPhysicalDiskInfo()
             }
         );
 
-        $PhysicalDiskData.Add($MSFTDiskId, $DiskInfo);
+        if(!$PhysicalDiskData.ContainsKey($MSFTDiskId)) {
+            $PhysicalDiskData.Add($MSFTDiskId, $DiskInfo);
+        }
     }
 
     return $PhysicalDiskData;


### PR DESCRIPTION
Fixes the exception "Item has already been added. Key in dictionary: 'x'  Key being added: 'x'" For the Plugin Invoke-IcingaCheckDiskHealth and potentially others too. Related to #327, which has been closed, but is still an issue for us on some machines.