### PR TITLE
Fix: `Invoke-IcingaCheckService` to properly include summary metrics for filtered services

### DIFF
--- a/doc/31-Changelog.md
+++ b/doc/31-Changelog.md
@@ -11,6 +11,10 @@ Released closed milestones can be found on [GitHub](https://github.com/Icinga/ic
 
 [Issue and PRs](https://github.com/Icinga/icinga-powershell-plugins/milestone/20)
 
+### Bugfixes
+
+* [#412](https://github.com/Icinga/icinga-powershell-plugins/pull/412) Fixes `Invoke-IcingaCheckService` to not add summary performance metrics in case the user filtered for specific services
+
 # 1.12.0 (2024-03-26)
 
 ### Bugfixes

--- a/plugins/Invoke-IcingaCheckService.psm1
+++ b/plugins/Invoke-IcingaCheckService.psm1
@@ -139,7 +139,7 @@ function Invoke-IcingaCheckService()
                 (New-IcingaWindowsServiceCheckObject -Status $Status -Service $services)
             );
 
-            $ServiceSummary = Add-IcingaServiceSummary -ServiceStatus $StatusRaw -ServiceData $ServiceSummary;
+            $ServiceSummary = Add-IcingaServiceSummary -ServiceStatus $services.configuration.Status.Raw -ServiceData $ServiceSummary;
         }
     }
 


### PR DESCRIPTION
Fixes `Invoke-IcingaCheckService` to not add summary performance metrics in case the user filtered for specific services