### PR TITLE
Fix: `Invoke-IcingaCheckDirectory` not working with brackets in path

### DIFF
--- a/doc/31-Changelog.md
+++ b/doc/31-Changelog.md
@@ -21,6 +21,7 @@ Released closed milestones can be found on [GitHub](https://github.com/Icinga/ic
 ### Bugfixes
 
 * [#398](https://github.com/Icinga/icinga-powershell-plugins/issues/398) Fixes an issue with service names not interpreted correctly by `Invoke-IcingaCheckService` in case it contains `[]`
+* [#401](https://github.com/Icinga/icinga-powershell-plugins/issues/401) Fixes `Invoke-IcingaCheckDirectory` which could not resolve `-Path` arguments in case closing `[` or open brackets `]` were part of the path
 * [#412](https://github.com/Icinga/icinga-powershell-plugins/pull/412) Fixes `Invoke-IcingaCheckService` to not add summary performance metrics in case the user filtered for specific services
 
 # 1.12.0 (2024-03-26)

--- a/provider/directory/Icinga_Provider_Directory.psm1
+++ b/provider/directory/Icinga_Provider_Directory.psm1
@@ -19,6 +19,8 @@ function Get-IcingaDirectoryAll()
         return;
     }
 
+    $Path = Rename-IcingaDirectoryPathEscaping -Path $Path;
+
     [hashtable]$DirectoryCollector = @{
         'FileList'     = $null;
         'FileCount'    = 0;
@@ -66,7 +68,9 @@ function Get-IcingaDirectoryAll()
     }
 
     foreach ($entry in $DirectoryData) {
-        if ((Get-Item $entry.FullName) -Is [System.IO.DirectoryInfo]) {
+        [string]$DirectoryPath = Rename-IcingaDirectoryPathEscaping -Path $entry.FullName;
+
+        if ((Get-Item $DirectoryPath) -Is [System.IO.DirectoryInfo]) {
             $DirectoryCollector.FolderCount += 1;
         } else {
             $DirectoryCollector.FileCount += 1;
@@ -260,4 +264,20 @@ function Get-IcingaDirectoryCreationTimeEqual()
     $DirectoryData = ($DirectoryData | Where-Object {$_.CreationTime.Day -eq $CreationTimeEqual.Day -And $_.CreationTime.Month -eq $CreationTimeEqual.Month -And $_.CreationTime.Year -eq $CreationTimeEqual.Year})
 
     return $DirectoryData;
+}
+
+function Rename-IcingaDirectoryPathEscaping()
+{
+    param (
+        [string]$Path = ''
+    );
+
+    if ($Path.Contains('[')) {
+        $Path = $Path.Replace('[', '`[');
+    }
+    if ($Path.Contains(']')) {
+        $Path = $Path.Replace(']', '`]');
+    }
+
+    return $Path;
 }


### PR DESCRIPTION
Fixes `Invoke-IcingaCheckDirectory` which could not resolve `-Path` arguments in case closing `[` or open brackets `]` were part of the path

Fixes #401