### PR TITLE
Fix: Service plugin for brackets in service names

### DIFF
--- a/doc/31-Changelog.md
+++ b/doc/31-Changelog.md
@@ -18,6 +18,7 @@ Released closed milestones can be found on [GitHub](https://github.com/Icinga/ic
 
 ### Bugfixes
 
+* [#398](https://github.com/Icinga/icinga-powershell-plugins/issues/398) Fixes an issue with service names not interpreted correctly by `Invoke-IcingaCheckService` in case it contains `[]`
 * [#412](https://github.com/Icinga/icinga-powershell-plugins/pull/412) Fixes `Invoke-IcingaCheckService` to not add summary performance metrics in case the user filtered for specific services
 
 # 1.12.0 (2024-03-26)

--- a/plugins/Invoke-IcingaCheckService.psm1
+++ b/plugins/Invoke-IcingaCheckService.psm1
@@ -150,6 +150,7 @@ function Invoke-IcingaCheckService()
 
     # Check our included services and add an unknown state for each service which was not found on the system
     foreach ($ServiceArg in $Service) {
+        $ServiceArg = $ServiceArg.Replace('`', '');
         if ($null -eq $FetchedServices -Or $FetchedServices.ContainsKey($ServiceArg) -eq $FALSE) {
             if ($ServiceArg.Contains('*')) {
                 continue;


### PR DESCRIPTION
Fixes an issue with service names not interpreted correctly by `Invoke-IcingaCheckService` in case it contains `[]`

Fixes #398