### PR TITLE
Fix: Removes process list for `Invoke-IcingaCheckCPU`

### DIFF
--- a/doc/31-Changelog.md
+++ b/doc/31-Changelog.md
@@ -16,6 +16,7 @@ Released closed milestones can be found on [GitHub](https://github.com/Icinga/ic
 * [#397](https://github.com/Icinga/icinga-powershell-plugins/issues/397) Adds support to `Invoke-IcingaCheckEventLog` to provide occurring problem event id's for the Eventlog and corresponding acknowledgement id's, providing an indicator if certain issues are resolved or still present
 * [#409](https://github.com/Icinga/icinga-powershell-plugins/issues/409) Adds support to `Invoke-IcingaCheckProcess` for reporting properly if a defined process was not found on the system and using `-OverrideNotFound` argument to define the plugin output in this case
 * [#413](https://github.com/Icinga/icinga-powershell-plugins/pull/413) Adds argument `Limit100Percent` to `Invoke-IcingaCheckCPU` for limiting each threads CPU usage to 100%
+* [#419](https://github.com/Icinga/icinga-powershell-plugins/pull/419) Removes process list feature for `Invoke-IcingaCheckCPU`, which causes too much CPU overhead and increase execution time by a lot without substantial gain of information
 
 ### Bugfixes
 

--- a/plugins/Invoke-IcingaCheckCPU.psm1
+++ b/plugins/Invoke-IcingaCheckCPU.psm1
@@ -139,6 +139,10 @@ function Invoke-IcingaCheckCPU()
         $CpuPackage.AddCheck($IcingaCheck);
     }
 
+    <#
+    # This code right now causes a huge performance impact on the plugin execution time.
+    # We will remove this feature for now
+    # Todo: Rework with a better performance
     if ($DisableProcessList -eq $FALSE) {
         $ProcessData   = Get-IcingaProviderDataValuesProcess;
         [bool]$HasData = $FALSE;
@@ -157,6 +161,7 @@ function Invoke-IcingaCheckCPU()
 
         $CpuPackage.AddCheck($ProcessPackage);
     }
+    #>
 
     return (New-IcingaCheckResult -Name 'CPU Load' -Check $CpuPackage -NoPerfData $NoPerfData -Compile);
 }


### PR DESCRIPTION
Removes process list feature for `Invoke-IcingaCheckCPU`, which causes too much CPU overhead and increase execution time by a lot without substantial gain of information

Fixes #418