### PR TITLE
Apply Minimum correctly to individual HTTPStatus-Checks

### DIFF
--- a/plugins/Invoke-IcingaCheckHTTPStatus.psm1
+++ b/plugins/Invoke-IcingaCheckHTTPStatus.psm1
@@ -117,7 +117,7 @@ function Invoke-IcingaCheckHTTPStatus()
         $Minimum = $Url.Count;
     }
 
-    $HTTPAllStatusPackage = New-IcingaCheckPackage -Name "HTTP Status Check" -OperatorAnd -Verbose $Verbosity -AddSummaryHeader;
+    $HTTPAllStatusPackage = New-IcingaCheckPackage -Name "HTTP Status Check" -OperatorMin $Minimum -Verbose $Verbosity -AddSummaryHeader;
 
     foreach ($SingleUrl in $Url) {
 
@@ -181,9 +181,9 @@ function Invoke-IcingaCheckHTTPStatus()
 
         # Content Package
         if ($HTTPData.$SingleUrl.'StatusCodes'.Value -ne $null) {
-            $ContentPackage = New-IcingaCheckPackage -Name "HTTP Content Check" -OperatorMin $Minimum -Verbose $Verbosity -IgnoreEmptyPackage;
+            $ContentPackage = New-IcingaCheckPackage -Name "HTTP Content Check" -Verbose $Verbosity -IgnoreEmptyPackage;
         } else {
-            $ContentPackage = New-IcingaCheckPackage -Name "HTTP Content Check" -OperatorMin $Minimum -Verbose $Verbosity -IgnoreEmptyPackage -Hidden;
+            $ContentPackage = New-IcingaCheckPackage -Name "HTTP Content Check" -Verbose $Verbosity -IgnoreEmptyPackage -Hidden;
         }
 
         # Found & Not Found


### PR DESCRIPTION
The `Minimum` Parameter of `Invoke-IcingaCheckHTTPStatus` supposedly (there is not much documentation) allows one to define how many sub checks must be OK for the main check to be OK.
I did assume that this meant each individual URL given (e.g. `Invoke-IcingaCheckHTTPStatus -URL https://foo.bar,https://bar.foo,https://baz.baz -Minimum 2` would be OK if checks fail for one URL but not for two) and changed to logic in the plugin accordingly.

If that is not the case and the parameter was meant for sub checks regarding each individual URL I would propose another parameter which does what I think :-) 


ref NC/849479

