### PR TITLE
Fix: Invoke-IcingaCheckPerfCounter to always write proper assigned perf data

### DIFF
--- a/doc/31-Changelog.md
+++ b/doc/31-Changelog.md
@@ -19,6 +19,7 @@ Released closed milestones can be found on [GitHub](https://github.com/Icinga/ic
 
 ### Bugfixes
 
+* [#377](https://github.com/Icinga/icinga-powershell-plugins/issues/377) Fixes `Invoke-IcingaCheckPerfCounter` to write correct performance data in case only certain instances are checked to ensure perf data are assigned to checks accordingly
 * [#436](https://github.com/Icinga/icinga-powershell-plugins/issues/436) Fixes performance data for ScheduledTask plugin for Last and Next RunTime
 
 ### Enhancements

--- a/plugins/Invoke-IcingaCheckPerfcounter.psm1
+++ b/plugins/Invoke-IcingaCheckPerfcounter.psm1
@@ -107,8 +107,14 @@ function Invoke-IcingaCheckPerfCounter()
             $CounterFailed = $FALSE;
 
             if ($instance -IsNot [hashtable]) {
-                $CounterInfo = Get-IcingaPerformanceCounterDetails -Counter $counter;
-                $IcingaCheck = New-IcingaCheck -Name $counter -Value $Counters[$counter].Value -MetricIndex $CounterInfo.Category -MetricName $CounterInfo.Counter;
+                $CounterInfo        = Get-IcingaPerformanceCounterDetails -Counter $counter;
+                [string]$MetricName = $CounterInfo.Counter;
+
+                if ([string]::IsNullOrEmpty($CounterInfo.CounterInstance) -eq $FALSE) {
+                    $MetricName = $CounterInfo.CounterInstance;
+                }
+
+                $IcingaCheck = New-IcingaCheck -Name $counter -Value $Counters[$counter].Value -MetricIndex $CounterInfo.Category -MetricName $MetricName;
                 $IcingaCheck.WarnOutOfRange($Warning).CritOutOfRange($Critical) | Out-Null;
                 $CounterPackage.AddCheck($IcingaCheck);
                 break;


### PR DESCRIPTION
Fixes `Invoke-IcingaCheckPerfCounter` to write correct performance data in case only certain instances are checked to ensure perf data are assigned to checks accordingly

Fixes #377