### PR TITLE
Fix: Invoke-IcingaCheckUpdates to properly report critical for -CritOnReboot

### DIFF
--- a/doc/31-Changelog.md
+++ b/doc/31-Changelog.md
@@ -19,6 +19,7 @@ Released closed milestones can be found on [GitHub](https://github.com/Icinga/ic
 
 ### Bugfixes
 
+* [#351](https://github.com/Icinga/icinga-powershell-plugins/issues/351) Fixes `Invoke-IcingaCheckUpdates` to properly report critical for `-CritOnReboot`
 * [#377](https://github.com/Icinga/icinga-powershell-plugins/issues/377) Fixes `Invoke-IcingaCheckPerfCounter` to write correct performance data in case only certain instances are checked to ensure perf data are assigned to checks accordingly
 * [#420](https://github.com/Icinga/icinga-powershell-plugins/issues/420) Fixes `Invoke-IcingaCheckUptime` to report a more human readable output for the current uptime in the package name
 * [#436](https://github.com/Icinga/icinga-powershell-plugins/issues/436) Fixes performance data for ScheduledTask plugin for Last and Next RunTime

--- a/plugins/Invoke-IcingaCheckUpdates.psm1
+++ b/plugins/Invoke-IcingaCheckUpdates.psm1
@@ -103,7 +103,7 @@ function Invoke-IcingaCheckUpdates()
         $RebootPending.WarnIfMatch([int][bool]$WarnOnReboot) | Out-Null;
     }
     if ($CritOnReboot) {
-        $RebootPending.CritIfMatch([int][bool]$WarnOnReboot) | Out-Null;
+        $RebootPending.CritIfMatch([int][bool]$CritOnReboot) | Out-Null;
     }
 
     $TotalPendingUpdates.WarnOutOfRange($Warning).CritOutOfRange($Critical) | Out-Null;


### PR DESCRIPTION
Fixes `Invoke-IcingaCheckUpdates` to properly report critical for `-CritOnReboot`

Fixes #351