### PR TITLE
Feature: Adds new feature to ship directory plugin checks with notice output

### DIFF
--- a/doc/31-Changelog.md
+++ b/doc/31-Changelog.md
@@ -14,6 +14,7 @@ Released closed milestones can be found on [GitHub](https://github.com/Icinga/ic
 ### Bugfixes
 
 * [#453](https://github.com/Icinga/icinga-powershell-plugins/pull/453) Fixes `Invoke-IcingaCheckPartitionSpace` to properly report the total size of partition, even when user disk quotas are set
+* [#455](https://github.com/Icinga/icinga-powershell-plugins/pull/455) Adds support for `Invoke-IcingaCheckDirectory` to output the content of `-FileList` as new output type `[INFO]` every time
 
 ### Enhancements
 

--- a/icinga-powershell-plugins.psd1
+++ b/icinga-powershell-plugins.psd1
@@ -6,7 +6,7 @@
     Copyright         = '(c) 2025 Icinga GmbH | GPLv2'
     Description       = 'A collection of Icinga Plugins for general Windows checks for Icinga for Windows.'
     PowerShellVersion = '4.0'
-    RequiredModules   = @(@{ModuleName = 'icinga-powershell-framework'; ModuleVersion = '1.13.3' })
+    RequiredModules   = @(@{ModuleName = 'icinga-powershell-framework'; ModuleVersion = '1.14.0' })
     NestedModules     = @(
         '.\compiled\icinga-powershell-plugins.ifw_compilation.psm1'
     )

--- a/plugins/Invoke-IcingaCheckDirectory.psm1
+++ b/plugins/Invoke-IcingaCheckDirectory.psm1
@@ -203,13 +203,13 @@ function Invoke-IcingaCheckDirectory()
     $DirectoryCheck = New-IcingaCheckPackage -Name ([string]::Format('Directory Check: "{0}"', $Path)) -OperatorAnd -Verbose $Verbosity -AddSummaryHeader;
 
     if ($ShowFileList) {
-        $DirectoryFileList = New-IcingaCheckPackage -Name 'File List' -OperatorAnd -Verbose 3;
+        $DirectoryFileList = New-IcingaCheckPackage -Name 'File List' -IsNoticePackage -OperatorAnd -Verbose 3;
 
         foreach ($entry in $DirectoryData.FileList) {
-            $FileDetailPackage = New-IcingaCheckPackage -Name $entry.FullName -OperatorAnd -Verbose 3;
+            $FileDetailPackage = New-IcingaCheckPackage -Name $entry.FullName -IsNoticePackage -OperatorAnd -Verbose 3;
 
             $FileDetailPackage.AddCheck(
-                (New-IcingaCheck -Name 'File Size' -Value $entry.Length -Unit 'B' -NoPerfData)
+                (New-IcingaCheck -Name 'File Size' -Value $entry.Length -Unit 'B' -NoPerfData).SetNotice()
             );
 
             $DirectoryFileList.AddCheck($FileDetailPackage);


### PR DESCRIPTION
Changes file list output for `Invoke-IcingaCheckDirectory` to always use the new `[INFO]` output type introduced with Icinga for Windows v1.14.0