### PR TITLE
Feature: Adds empty package ignore for CPU plugin

### DIFF
--- a/doc/31-Changelog.md
+++ b/doc/31-Changelog.md
@@ -18,6 +18,7 @@ Released closed milestones can be found on [GitHub](https://github.com/Icinga/ic
 
 ### Enhancements
 
+* [#447](https://github.com/Icinga/icinga-powershell-plugins/issues/447) Changes package behavior for `Invoke-IcingaCheckCPU` to automatically ignore empty packages because of the usage of `\Processor(*)\% Processor Time` counter instead of `\Processor Information(*)\% Processor Utility`
 * [#450](https://github.com/Icinga/icinga-powershell-plugins/pull/450) Adds support for access time to `Invoke-IcingaCheckDirectory`
 * [#451](https://github.com/Icinga/icinga-powershell-plugins/pull/451) Adds support to override the plugin output for `Invoke-IcingaCheckService` with `-OverrideNotOk` in for thresholds not matching the service running state
 * [#455](https://github.com/Icinga/icinga-powershell-plugins/pull/455) Adds support for `Invoke-IcingaCheckDirectory` to output the content of `-FileList` as new output type `[INFO]` every time

--- a/plugins/Invoke-IcingaCheckCPU.psm1
+++ b/plugins/Invoke-IcingaCheckCPU.psm1
@@ -90,7 +90,7 @@ function Invoke-IcingaCheckCPU()
             continue;
         }
 
-        $SocketPackage = New-IcingaCheckPackage -Name $socket.Name -OperatorAnd -Verbose $Verbosity;
+        $SocketPackage = New-IcingaCheckPackage -Name $socket.Name -OperatorAnd -Verbose $Verbosity -IgnoreEmptyPackage;
 
         foreach ($thread in (Get-IcingaProviderElement $socket.Value)) {
             # Transform "_Total" to "Total"


### PR DESCRIPTION
Changes package behavior for `Invoke-IcingaCheckCPU` to automatically ignore empty packages because of the usage of `\Processor(*)\% Processor Time` counter instead of `\Processor Information(*)\% Processor Utility`

Fixes #447