### PR TITLE
Feature: Adds volume names to disk health plugin for easier understanding which disks are affected by certain thresholds

### DIFF
--- a/doc/31-Changelog.md
+++ b/doc/31-Changelog.md
@@ -26,6 +26,7 @@ Released closed milestones can be found on [GitHub](https://github.com/Icinga/ic
 * [#457](https://github.com/Icinga/icinga-powershell-plugins/pull/457) Adds improved handling for partition plugin, which now also include mount points for MSSQL for example
 * [#461](https://github.com/Icinga/icinga-powershell-plugins/pull/461) Updates MPIO plugin to use volume names instead of MPIO disk id's and allows thresholds for number of path assigned based on the volume name filter
 * [#462](https://github.com/Icinga/icinga-powershell-plugins/issues/462) Fixes documentation for `Invoke-IcingaCheckMemory` and `Inboke-IcingaCheckPartitionSpace` to better describe on how `%`monitoring works
+* [#466](https://github.com/Icinga/icinga-powershell-plugins/pull/466) Adds support for the disk health plugin to display not only the assigned driver letters to a disk but also the volume names
 
 ## 1.13.1 (2025-05-08)
 

--- a/plugins/Invoke-IcingaCheckDiskHealth.psm1
+++ b/plugins/Invoke-IcingaCheckDiskHealth.psm1
@@ -299,11 +299,30 @@ function Invoke-IcingaCheckDiskHealth()
                         -NoPerfData
                 ).SetOk([string]$DiskObjects.Data.MediaType.Name, $TRUE)
             );
+
+            # Add assigned drive letters and volume names, but set default to None if none found
+            [string]$DriveReference = 'None';
+            [string]$VolumeNames    = 'None';
+            if ($DiskObjects.Data.DriveReference.Count -gt 0) {
+                $DriveReference = $DiskObjects.Data.DriveReference.Keys -Join '; ';
+            }
+            if ($DiskObjects.Data.VolumeNames.Count -gt 0) {
+                $VolumeNames = $DiskObjects.Data.VolumeNames -Join '; ';
+            }
+
             $PartCheckPackage.AddCheck(
                 (
                     New-IcingaCheck `
                         -Name ([string]::Format('{0} Assigned Partitions', $Partition)) `
-                        -Value ($DiskObjects.Data.DriveReference.Keys | Out-String).Replace("`r`n", ' ').Replace("`n", ' ') `
+                        -Value $DriveReference `
+                        -NoPerfData
+                )
+            );
+            $PartCheckPackage.AddCheck(
+                (
+                    New-IcingaCheck `
+                        -Name ([string]::Format('{0} Assigned Volumes', $Partition)) `
+                        -Value $VolumeNames `
                         -NoPerfData
                 )
             );


### PR DESCRIPTION
Adds support for the disk health plugin to display not only the assigned driver letters to a disk but also the volume names.

```powershell
\_ [OK] Disk #1 (All must be [OK])
   \_ [INFO] 1 Assigned Partitions: None
   \_ [INFO] 1 Assigned Volumes: TestVolume; TestVolume2
   \_ [INFO] 1 avg. disk queue length: 0%
   \_ [INFO] 1 avg. disk sec/read: 0us
   \_ [INFO] 1 avg. disk sec/transfer: 0us
   \_ [INFO] 1 avg. disk sec/write: 0us
```