### PR TITLE
Fix: Invoke-IcingaCheckPartitionSpace to report unknown if no usage data was found

### DIFF
--- a/doc/31-Changelog.md
+++ b/doc/31-Changelog.md
@@ -13,6 +13,7 @@ Released closed milestones can be found on [GitHub](https://github.com/Icinga/ic
 
 ### Bugfixes
 
+* [#471](https://github.com/Icinga/icinga-powershell-plugins/pull/471) Fixes `Invoke-IcingaCheckPartitionSpace` to report `UNKNOWN` if no usage data was used, which was previously handled by "No disk size available". As we now properly receive disk size data but still no usage data in these cases, we receive false positives
 * [#472](https://github.com/Icinga/icinga-powershell-plugins/pull/472) Fixes the partition size provider to no longer map the volume to partition by using the drive letter, but the device id instead, to ensure real partition size is applied for every use case
 
 ## 1.14.0 (2026-02-11)

--- a/plugins/Invoke-IcingaCheckUsedPartitionSpace.psm1
+++ b/plugins/Invoke-IcingaCheckUsedPartitionSpace.psm1
@@ -181,6 +181,12 @@ function Invoke-IcingaCheckPartitionSpace()
             } else {
                 $IcingaCheck.SetOk('No disk size available', $TRUE) | Out-Null;
             }
+        } elseif ([string]::IsNullOrEmpty($partition.FreeSpace) -or [string]::IsNullOrEmpty($partition.UsedSpace)) {
+            if ($SkipUnknown -eq $FALSE) {
+                $IcingaCheck.SetUnknown('No disk usage size available', $TRUE) | Out-Null;
+            } else {
+                $IcingaCheck.SetOk('No disk usage available', $TRUE) | Out-Null;
+            }
         } else {
             $IcingaCheck.WarnOutOfRange($Warning).CritOutOfRange($Critical) | Out-Null;
         }

--- a/provider/disks/Get-IcingaPartitionSpace.psm1
+++ b/provider/disks/Get-IcingaPartitionSpace.psm1
@@ -32,12 +32,18 @@ function Get-IcingaPartitionSpace()
             break;
         }
 
+        $UsedSpace = $null;
+
+        if ($null -ne $disk.FreeSpace) {
+            $UsedSpace = $DiskSize - [decimal]$disk.FreeSpace;
+        }
+
         $DiskData.Add(
             $disk.Name,
             @{
                 'Size'        = $DiskSize;
                 'FreeSpace'   = $disk.FreeSpace;
-                'UsedSpace'   = ($DiskSize - $disk.FreeSpace);
+                'UsedSpace'   = $UsedSpace;
                 'DriveLetter' = $disk.DriveLetter;
                 'DriveName'   = $disk.Name;
                 'HasLetter'   = -not [string]::IsNullOrEmpty($disk.DriveLetter);


### PR DESCRIPTION
Fixes `Invoke-IcingaCheckPartitionSpace` to report `UNKNOWN` if no usage data was used, which was previously handled by "No disk size available". As we now properly receive disk size data but still no usage data in these cases, we receive false positives