### PR TITLE
Fix: Partition data provider to always update the maximum partition size by checking the volume device id for the assigned partition

### DIFF
--- a/doc/31-Changelog.md
+++ b/doc/31-Changelog.md
@@ -7,6 +7,14 @@ documentation before upgrading to a new release.
 
 Released closed milestones can be found on [GitHub](https://github.com/Icinga/icinga-powershell-plugins/milestones?state=closed).
 
+## 1.14.1 (2026-03-31)
+
+[Issue and PRs](https://github.com/Icinga/icinga-powershell-plugins/milestone/23)
+
+### Bugfixes
+
+* [#472](https://github.com/Icinga/icinga-powershell-plugins/pull/472) Fixes the partition size provider to no longer map the volume to partition by using the drive letter, but the device id instead, to ensure real partition size is applied for every use case
+
 ## 1.14.0 (2026-02-11)
 
 [Issue and PRs](https://github.com/Icinga/icinga-powershell-plugins/milestone/22)

--- a/provider/disks/Get-IcingaPartitionSpace.psm1
+++ b/provider/disks/Get-IcingaPartitionSpace.psm1
@@ -21,14 +21,10 @@ function Get-IcingaPartitionSpace()
         # Create a fallback value - shouldn't apply anyway
         [decimal]$DiskSize = $disk.Capacity;
 
-        # Now loop through all our partitions for the partition with our drive letter and
-        # get the actual size from there, ignoring possible user quotas
+        # Now loop through all our partitions and check if the disk device id
+        # is mapped to one of the partitions access paths
         foreach ($partition in $Partitions) {
-            if ([string]::IsNullOrEmpty($partition.DriveLetter) -or [string]::IsNullOrEmpty($disk.DriveLetter)) {
-                continue;
-            }
-
-            if ($partition.DriveLetter -ne $disk.DriveLetter.Replace(':', '').Replace('\', '')) {
+            if ($partition.AccessPaths -notcontains $disk.DeviceID) {
                 continue;
             }
 


### PR DESCRIPTION
Fixes the partition size provider to no longer map the volume to partition by using the drive letter, but the device id instead, to ensure real partition size is applied for every use case