### PR TITLE
Fix: Network include filter being broken and never being applied properly

### DIFF
--- a/doc/31-Changelog.md
+++ b/doc/31-Changelog.md
@@ -7,6 +7,14 @@ documentation before upgrading to a new release.
 
 Released closed milestones can be found on [GitHub](https://github.com/Icinga/icinga-powershell-plugins/milestones?state=closed).
 
+## 1.15.0 (2026-06-30)
+
+[Issue and PRs](https://github.com/Icinga/icinga-powershell-plugins/milestone/24)
+
+### Bugfixes
+
+* [#479](https://github.com/Icinga/icinga-powershell-plugins/pull/479) Fixes Network include filter for `Invoke-IcingaCheckNetworkInterface` being broken and never being applied properly
+
 ## 1.14.1 (2026-03-31)
 
 [Issue and PRs](https://github.com/Icinga/icinga-powershell-plugins/milestone/23)

--- a/provider/network/Join-icingaNetworkDeviceDataPerfCounter.psm1
+++ b/provider/network/Join-icingaNetworkDeviceDataPerfCounter.psm1
@@ -28,19 +28,11 @@ function Join-IcingaNetworkDeviceDataPerfCounter()
             continue;
         }
 
-        if ((Test-IcingaArrayFilter -InputObject $GetNetworkDevice[$DeviceName].DeviceId -Include $IncludeNetworkDevice -Exclude $ExcludeNetworkDevice) -eq $FALSE) {
-            continue;
-        }
-
-        if ((Test-IcingaArrayFilter -InputObject $DeviceName -Include $IncludeNetworkDevice -Exclude $ExcludeNetworkDevice) -eq $FALSE) {
-            continue;
-        }
-
         if ((Test-IcingaArrayFilter -InputObject $GetNetworkDevice[$DeviceName].Name -Include $IncludeNetworkDevice -Exclude $ExcludeNetworkDevice) -eq $FALSE) {
             continue;
         }
 
-        if (($GetNetworkDevice.Containskey($DeviceName)) -eq $fALSE) {
+        if (($GetNetworkDevice.ContainsKey($DeviceName)) -eq $fALSE) {
             continue;
         }
 
@@ -51,7 +43,7 @@ function Join-IcingaNetworkDeviceDataPerfCounter()
                 foreach ($key in $NetworkDeviceObject.Keys) {
                     $CounterObject = $NetworkDeviceObject[$key];
                     if (($CounterHashObject.ContainsKey($key)) -eq $TRUE) {
-                        $CounterHashObject[$key].value += $CounterObject.value; 
+                        $CounterHashObject[$key].value += $CounterObject.value;
                     } else {
                         $CounterHashObject.Add($key, $CounterObject);
                     }


### PR DESCRIPTION
The include network interface filter for `Invoke-IcingaCheckNetworkInterface` was never able to include any filtered object, as it checked for the device id, device name and interface name at the same time.

For easier usage, the filter will now only work for the interface name for both, include and exclude filter for the interface.