### PR TITLE
Fix: Network device mapping for #, /, and _ as part of the name

### DIFF
--- a/doc/31-Changelog.md
+++ b/doc/31-Changelog.md
@@ -14,6 +14,7 @@ Released closed milestones can be found on [GitHub](https://github.com/Icinga/ic
 ### Bugfixes
 
 * [#479](https://github.com/Icinga/icinga-powershell-plugins/pull/479) Fixes Network include filter for `Invoke-IcingaCheckNetworkInterface` being broken and never being applied properly
+* [#482](https://github.com/Icinga/icinga-powershell-plugins/pull/482) Fixes network device mapping for performance counter metrics to network devices, which could contain `#`, `/` or simply just `_`
 
 ## 1.14.1 (2026-03-31)
 

--- a/provider/network/Join-icingaNetworkDeviceDataPerfCounter.psm1
+++ b/provider/network/Join-icingaNetworkDeviceDataPerfCounter.psm1
@@ -21,7 +21,22 @@ function Join-IcingaNetworkDeviceDataPerfCounter()
         $DeviceName          = $DeviceName.Replace('[', '(').Replace(']', ')');
 
         if ([regex]::Match($DeviceName, '_').success) {
-            $DeviceName = $DeviceName.Replace('_', '#');
+            $TmpDeviceName = $DeviceName.Replace('_', '#');
+
+            # Check if the device is found with a #
+            if (($GetNetworkDevice.ContainsKey($TmpDeviceName))) {
+                $DeviceName = $TmpDeviceName;
+            } else {
+                $TmpDeviceName = $DeviceName.Replace('_', '/');
+
+                # If not, check if the device is found with a / in name
+                if (($GetNetworkDevice.ContainsKey($TmpDeviceName))) {
+                    $DeviceName = $TmpDeviceName;
+                } elseif (($GetNetworkDevice.ContainsKey($DeviceName)) -eq $FALSE) {
+                    # If all substitutions fail and the original name with _ is not found either, skip
+                    continue;
+                }
+            }
         }
 
         if (($IncludeHiddenNetworkDevice -eq $False) -And $GetNetworkDevice[$DeviceName].Hidden -eq $TRUE) {
@@ -29,10 +44,6 @@ function Join-IcingaNetworkDeviceDataPerfCounter()
         }
 
         if ((Test-IcingaArrayFilter -InputObject $GetNetworkDevice[$DeviceName].Name -Include $IncludeNetworkDevice -Exclude $ExcludeNetworkDevice) -eq $FALSE) {
-            continue;
-        }
-
-        if (($GetNetworkDevice.ContainsKey($DeviceName)) -eq $fALSE) {
             continue;
         }
 


### PR DESCRIPTION
Fixes network device mapping for performance counter metrics to network devices, which could contain `#`, `/` or simply just `_`