### PR TITLE
Fix: Use label names for partitions before device names

### DIFF
--- a/doc/31-Changelog.md
+++ b/doc/31-Changelog.md
@@ -11,6 +11,10 @@ Released closed milestones can be found on [GitHub](https://github.com/Icinga/ic
 
 [Issue and PRs](https://github.com/Icinga/icinga-powershell-plugins/milestone/25)
 
+### Bugfixes
+
+* [#488](https://github.com/Icinga/icinga-powershell-plugins/pull/488) Fixes partition space plugin to use partition label names instead of disk names if given
+
 ## 1.15.0 (2026-06-30)
 
 [Issue and PRs](https://github.com/Icinga/icinga-powershell-plugins/milestone/24)

--- a/plugins/Invoke-IcingaCheckUsedPartitionSpace.psm1
+++ b/plugins/Invoke-IcingaCheckUsedPartitionSpace.psm1
@@ -134,10 +134,10 @@ function Invoke-IcingaCheckPartitionSpace()
     }
 
     foreach ($partition in $Disks.Keys) {
-        $partition          = $Disks[$partition];
-        $ProcessPartition   = $TRUE;
-        $PartitionMandatory = $FALSE;
-        $PartitionName      = $partition.DriveLetter;
+        $partition             = $Disks[$partition];
+        $ProcessPartition      = $TRUE;
+        $PartitionMandatory    = $FALSE;
+        [string]$PartitionName = $partition.DriveLetter;
 
         $FormattedLetter = '';
         if ([string]::IsNullOrEmpty($partition.DriveLetter) -eq $FALSE) {
@@ -145,19 +145,22 @@ function Invoke-IcingaCheckPartitionSpace()
             $KnownPartitions += $FormattedLetter;
         } else {
             $PartitionName    = $partition.DriveName;
+            if (-not ([string]::IsNullOrEmpty($partition.Label))) {
+                $PartitionName = $partition.Label;
+            }
             $KnownPartitions += $PartitionName.ToLower();
         }
 
         foreach ($entry in $Include) {
             $ProcessPartition = $FALSE;
 
-            if (($partition.HasLetter -and (Test-IcingaArrayFilter -InputObject $FormattedLetter -Include $entry.Replace(':', '').Replace('\', '').Replace('/', '').ToLower())) -or (-not $partition.HasLetter -and (Test-IcingaArrayFilter -InputObject $partition.DriveName.ToLower() -Include $entry.ToLower()))) {
+            if (($partition.HasLetter -and (Test-IcingaArrayFilter -InputObject $FormattedLetter -Include $entry.Replace(':', '').Replace('\', '').Replace('/', '').ToLower())) -or (-not $partition.HasLetter -and (Test-IcingaArrayFilter -InputObject $PartitionName.ToLower() -Include $entry.ToLower()))) {
                 $ProcessPartition = $TRUE;
                 break;
             }
         }
         foreach ($entry in $Exclude) {
-            if (($partition.HasLetter -and (Test-IcingaArrayFilter -InputObject $FormattedLetter -Exclude $entry.Replace(':', '').Replace('\', '').Replace('/', '').ToLower()) -eq $FALSE) -or (-not $partition.HasLetter -and (Test-IcingaArrayFilter -InputObject $partition.DriveName.ToLower() -Exclude $entry.ToLower()) -eq $FALSE)) {
+            if (($partition.HasLetter -and (Test-IcingaArrayFilter -InputObject $FormattedLetter -Exclude $entry.Replace(':', '').Replace('\', '').Replace('/', '').ToLower()) -eq $FALSE) -or (-not $partition.HasLetter -and (Test-IcingaArrayFilter -InputObject $PartitionName.ToLower() -Exclude $entry.ToLower()) -eq $FALSE)) {
                 $ProcessPartition = $FALSE;
                 break;
             }

--- a/provider/disks/Get-IcingaPartitionSpace.psm1
+++ b/provider/disks/Get-IcingaPartitionSpace.psm1
@@ -47,6 +47,7 @@ function Get-IcingaPartitionSpace()
                 'DriveLetter' = $disk.DriveLetter;
                 'DriveName'   = $disk.Name;
                 'HasLetter'   = -not [string]::IsNullOrEmpty($disk.DriveLetter);
+                'Label'       = $disk.Label;
             }
         );
     }


### PR DESCRIPTION
Fixes partition space plugin to use partition label names instead of disk names if given